### PR TITLE
音声ファイルアップロード機能の追加

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "@nestjs/testing": "^11.0.1",
     "@types/express": "^5.0.0",
     "@types/jest": "^30.0.0",
+    "@types/multer": "^2.0.0",
     "@types/node": "^22.10.7",
     "@types/supertest": "^6.0.2",
     "@types/uuid": "^9.0.8",

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
+      '@types/multer':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/node':
         specifier: ^22.10.7
         version: 22.19.13
@@ -1249,6 +1252,9 @@ packages:
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
+
+  '@types/multer@2.0.0':
+    resolution: {integrity: sha512-C3Z9v9Evij2yST3RSBktxP9STm6OdMc5uR1xF1SGr98uv8dUlAL2hqwrZ3GVB3uyMyiegnscEK6PGtYvNrjTjw==}
 
   '@types/node@22.19.13':
     resolution: {integrity: sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==}
@@ -5174,6 +5180,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/methods@1.1.4': {}
+
+  '@types/multer@2.0.0':
+    dependencies:
+      '@types/express': 5.0.6
 
   '@types/node@22.19.13':
     dependencies:

--- a/backend/src/storage/interfaces/audio-storage.interface.ts
+++ b/backend/src/storage/interfaces/audio-storage.interface.ts
@@ -13,6 +13,9 @@ export interface AudioStorage {
 
   /** 音声ファイルの再生用URLを取得 */
   getPlaybackUrl(fileName: string): Promise<string>;
+
+  /** 音声ファイルを保存 */
+  saveFile(fileName: string, buffer: Buffer): Promise<void>;
 }
 
 /** DI用のインジェクショントークン */

--- a/backend/src/storage/local/local-audio-storage.ts
+++ b/backend/src/storage/local/local-audio-storage.ts
@@ -60,6 +60,11 @@ export class LocalAudioStorage implements AudioStorage {
     return `/outputs/${encodeURIComponent(fileName)}`;
   }
 
+  async saveFile(fileName: string, buffer: Buffer): Promise<void> {
+    await fs.writeFile(path.join(this.baseDir, fileName), buffer);
+    this.logger.log(`音声ファイル保存完了: ${fileName}`);
+  }
+
   /** ServeStaticModule用にbaseDirを公開 */
   getBaseDir(): string {
     return this.baseDir;

--- a/backend/src/storage/s3/s3-audio-storage.ts
+++ b/backend/src/storage/s3/s3-audio-storage.ts
@@ -5,6 +5,7 @@ import {
   ListObjectsV2Command,
   GetObjectCommand,
   HeadObjectCommand,
+  PutObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { AudioStorage } from '../interfaces/audio-storage.interface';
@@ -118,6 +119,24 @@ export class S3AudioStorage implements AudioStorage {
       this.logger.error(`S3署名付きURL生成に失敗: ${fileName}`, err);
       throw new Error(
         `S3署名付きURLの生成に失敗しました（${fileName}）: ${err.message}`,
+      );
+    }
+  }
+
+  async saveFile(fileName: string, buffer: Buffer): Promise<void> {
+    try {
+      await this.s3.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: `${this.prefix}${fileName}`,
+          Body: buffer,
+        }),
+      );
+      this.logger.log(`S3音声ファイル保存完了: ${fileName}`);
+    } catch (err: any) {
+      this.logger.error(`S3への音声ファイル保存に失敗: ${fileName}`, err);
+      throw new Error(
+        `S3への音声ファイル保存に失敗しました（${fileName}）: ${err.message}`,
       );
     }
   }

--- a/backend/src/transcription/transcription.controller.ts
+++ b/backend/src/transcription/transcription.controller.ts
@@ -5,7 +5,11 @@ import {
   Patch,
   Param,
   Body,
+  UseInterceptors,
+  UploadedFile,
+  BadRequestException,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { TranscriptionService } from './transcription.service';
 import { TranscribeRequestDto } from './dto/transcribe-request.dto';
 import { UpdateSpeakersDto } from './dto/update-speakers.dto';
@@ -22,6 +26,20 @@ export class TranscriptionController {
   async getAudioFiles() {
     const files = await this.transcriptionService.getAudioFiles();
     return { files };
+  }
+
+  /** 音声ファイルアップロード: POST /api/audio-files */
+  @Post('audio-files')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadAudioFile(@UploadedFile() file: Express.Multer.File) {
+    if (!file) {
+      throw new BadRequestException('ファイルが指定されていません');
+    }
+    await this.transcriptionService.uploadAudioFile(
+      file.originalname,
+      file.buffer,
+    );
+    return { fileName: file.originalname };
   }
 
   /** 音声ファイル再生URL取得: GET /api/audio-files/:fileName/url */

--- a/backend/src/transcription/transcription.service.ts
+++ b/backend/src/transcription/transcription.service.ts
@@ -56,6 +56,12 @@ export class TranscriptionService {
     return this.audioStorage.getPlaybackUrl(fileName);
   }
 
+  /** 音声ファイルをアップロード */
+  async uploadAudioFile(fileName: string, buffer: Buffer): Promise<void> {
+    await this.audioStorage.saveFile(fileName, buffer);
+    this.logger.log(`音声ファイルアップロード完了: ${fileName}`);
+  }
+
   /** 音声ファイルを文字起こし */
   async transcribe(fileName: string): Promise<Transcription> {
     if (!(await this.audioStorage.exists(fileName))) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -17,6 +17,21 @@ export async function fetchAudioFiles(): Promise<AudioFileInfo[]> {
   return data.files;
 }
 
+/** 音声ファイルをアップロード */
+export async function uploadAudioFile(file: File): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(`${BASE_URL}/audio-files`, {
+    method: 'POST',
+    body: formData,
+  });
+  if (!res.ok) {
+    throw new Error(`音声ファイルのアップロードに失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.fileName;
+}
+
 /** 音声ファイルの再生用URLを取得 */
 export async function fetchAudioFileUrl(fileName: string): Promise<string> {
   const res = await fetch(

--- a/frontend/src/components/AudioFileList.css
+++ b/frontend/src/components/AudioFileList.css
@@ -15,6 +15,32 @@
   padding: 0.3em 0.6em;
 }
 
+.audio-file-upload {
+  margin-bottom: 0.75rem;
+}
+
+.upload-button {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #3b82f6;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.upload-button:hover {
+  background-color: #2563eb;
+}
+
+.upload-button:disabled {
+  background-color: #93c5fd;
+  cursor: not-allowed;
+}
+
 .audio-file-list-error {
   background-color: #fef2f2;
   color: #991b1b;

--- a/frontend/src/components/AudioFileList.tsx
+++ b/frontend/src/components/AudioFileList.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { fetchAudioFiles } from '../api/client';
+import { useEffect, useRef, useState } from 'react';
+import { fetchAudioFiles, uploadAudioFile } from '../api/client';
 import type { AudioFileInfo } from '../types';
 import './AudioFileList.css';
 
@@ -20,14 +20,37 @@ function formatFileSize(bytes: number): string {
 export function AudioFileList({ selectedFile, onFileSelect, loading }: Props) {
   const [files, setFiles] = useState<AudioFileInfo[]>([]);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const loadFiles = async () => {
     try {
       setFetchError(null);
       const result = await fetchAudioFiles();
       setFiles(result);
-    } catch (e) {
-      setFetchError(e instanceof Error ? e.message : '取得に失敗しました');
+    } catch {
+      setFiles([]);
+    }
+  };
+
+  const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    try {
+      setUploading(true);
+      setFetchError(null);
+      await uploadAudioFile(file);
+      await loadFiles();
+    } catch (err) {
+      setFetchError(
+        err instanceof Error ? err.message : 'アップロードに失敗しました',
+      );
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     }
   };
 
@@ -42,21 +65,32 @@ export function AudioFileList({ selectedFile, onFileSelect, loading }: Props) {
         <button
           className="reload-button"
           onClick={loadFiles}
-          disabled={loading}
+          disabled={loading || uploading}
         >
           更新
         </button>
       </div>
 
+      <div className="audio-file-upload">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="audio/*,video/*,.mp3,.wav,.m4a,.ogg,.flac,.webm,.aac,.mp4"
+          onChange={handleUpload}
+          disabled={loading || uploading}
+          hidden
+        />
+        <button
+          className="upload-button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={loading || uploading}
+        >
+          {uploading ? 'アップロード中...' : 'ファイルをアップロード'}
+        </button>
+      </div>
+
       {fetchError && (
         <div className="audio-file-list-error">{fetchError}</div>
-      )}
-
-      {files.length === 0 && !fetchError && (
-        <p className="audio-file-list-empty">
-          音声ファイルがありません。<br />
-          backend/data/outputs/ フォルダにファイルを配置してください。
-        </p>
       )}
 
       <ul className="audio-file-list-items">


### PR DESCRIPTION
## Summary
- ブラウザから音声ファイルをアップロードできる機能を追加
- ファイル一覧取得失敗時のエラーメッセージを非表示に変更
- Local/S3両方のストレージでアップロードに対応

## 変更内容
- `AudioStorage` インターフェースに `saveFile` メソッドを追加
- `LocalAudioStorage` / `S3AudioStorage` にアップロード実装を追加
- `POST /api/audio-files` エンドポイントを追加（multipart/form-data）
- フロントエンドにアップロードボタンを追加（音声ファイル一覧の上に配置）

## Test plan
- [x] ローカル環境（STORAGE_TYPE=local）でファイルアップロードが動作する
- [x] S3環境（STORAGE_TYPE=s3）でファイルアップロードが動作する
- [x] アップロード後、ファイル一覧が自動更新される
- [x] アップロード中はボタンが無効化される
- [x] バックエンド・フロントエンドのビルドが成功する

🤖 Generated with [Claude Code](https://claude.com/claude-code)