### PR TITLE
feat: 発言の文脈分析機能を追加

### DIFF
--- a/backend/src/interview/claude.service.ts
+++ b/backend/src/interview/claude.service.ts
@@ -153,4 +153,73 @@ ${question}
 
     return { question, answer, sources };
   }
+
+  /** 発言の文脈分析プロンプトを構築 */
+  buildContextAnalysisPrompt(
+    allUtterances: { speakerName: string; text: string }[],
+    targetIndices: number[],
+  ): string {
+    const conversationLines = allUtterances
+      .map((u, i) => `[${i}] ${u.speakerName}: ${u.text}`)
+      .join('\n');
+
+    const targetList = targetIndices.join(', ');
+
+    return `以下の会話の文字起こしから、指定された発話の文脈を分析してください。
+
+## 会話全文
+${conversationLines}
+
+## 分析対象の発話番号
+${targetList}
+
+## 指示
+上記の発話番号に該当する各発話について、以下の2項目を分析してください:
+- 「intent」: 発言の意図（以下のいずれか: 質問, 回答, 同意, 反論, 補足, 提案, 説明, 感想, 挨拶, その他）
+- 「topic」: その発話の話題を10〜30文字程度で簡潔に記述
+
+## 出力形式
+以下のJSON配列のみを出力してください。JSON以外は出力しないでください。
+[
+  { "index": 0, "intent": "質問", "topic": "プロジェクトの進捗状況" }
+]`;
+  }
+
+  /** 発言の文脈を分析 */
+  async analyzeContext(
+    allUtterances: { speakerName: string; text: string }[],
+    targetIndices: number[],
+  ): Promise<{ index: number; intent: string; topic: string }[]> {
+    this.logger.log(`文脈分析開始: 対象=${targetIndices.length}件`);
+
+    const prompt = this.buildContextAnalysisPrompt(
+      allUtterances,
+      targetIndices,
+    );
+
+    const response = await this.client.messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 4096,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text =
+      response.content[0].type === 'text' ? response.content[0].text : '';
+
+    // JSONブロックを抽出してパース
+    const jsonMatch = text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) {
+      this.logger.error('文脈分析のJSON抽出に失敗');
+      throw new Error('文脈分析結果のパースに失敗しました');
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as {
+      index: number;
+      intent: string;
+      topic: string;
+    }[];
+
+    this.logger.log(`文脈分析完了: ${parsed.length}件`);
+    return parsed;
+  }
 }

--- a/backend/src/interview/dto/analyze-context.dto.ts
+++ b/backend/src/interview/dto/analyze-context.dto.ts
@@ -1,0 +1,7 @@
+/** 発言の文脈分析リクエストDTO */
+export class AnalyzeContextDto {
+  /** 文字起こしID */
+  transcriptionId: string;
+  /** 分析対象の発話インデックス（utterances配列のインデックス） */
+  utteranceIndices: number[];
+}

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Post, Body } from '@nestjs/common';
 import { InterviewService } from './interview.service';
 import { GenerateQuestionsDto } from './dto/generate-questions.dto';
 import { AnalyzeDto } from './dto/analyze.dto';
+import { AnalyzeContextDto } from './dto/analyze-context.dto';
 
 /** 会話分析APIコントローラー */
 @Controller('interview')
@@ -39,6 +40,16 @@ export class InterviewController {
       dto.speakerId,
       dto.keywords,
       dto.questions,
+    );
+    return { analysis };
+  }
+
+  /** 発言の文脈分析: POST /api/interview/analyze-context */
+  @Post('analyze-context')
+  async analyzeContext(@Body() dto: AnalyzeContextDto) {
+    const analysis = await this.interviewService.analyzeContext(
+      dto.transcriptionId,
+      dto.utteranceIndices,
     );
     return { analysis };
   }

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -2,7 +2,11 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { ClaudeService } from './claude.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
-import { InterviewAnalysis } from './types/interview.types';
+import {
+  InterviewAnalysis,
+  UtteranceContextResult,
+  ContextAnalysisResponse,
+} from './types/interview.types';
 
 /** 会話分析のビジネスロジックを担当するサービス */
 @Injectable()
@@ -96,5 +100,63 @@ export class InterviewService {
       results,
       createdAt: new Date().toISOString(),
     };
+  }
+
+  /** 発言の文脈を分析 */
+  async analyzeContext(
+    transcriptionId: string,
+    utteranceIndices: number[],
+  ): Promise<ContextAnalysisResponse> {
+    const transcription = await this.store.findById(transcriptionId);
+    if (!transcription) {
+      throw new NotFoundException(
+        `文字起こし結果が見つかりません: ${transcriptionId}`,
+      );
+    }
+
+    this.logger.log(
+      `文脈分析開始: transcriptionId=${transcriptionId}, 対象=${utteranceIndices.length}件`,
+    );
+
+    // 全発話を簡略化して渡す
+    const allUtterances = transcription.utterances.map((u) => ({
+      speakerName: u.speakerName,
+      text: u.text,
+    }));
+
+    // Claude APIで意図・話題を分析
+    const llmResults = await this.claudeService.analyzeContext(
+      allUtterances,
+      utteranceIndices,
+    );
+
+    // LLM結果をインデックスでマッピング
+    const llmMap = new Map(llmResults.map((r) => [r.index, r]));
+
+    // 結果を組み立て（直前の発話はデータから抽出）
+    const results: UtteranceContextResult[] = utteranceIndices.map((idx) => {
+      const utterance = transcription.utterances[idx];
+      const llm = llmMap.get(idx);
+
+      const previousUtterance =
+        idx > 0
+          ? {
+              speakerName: transcription.utterances[idx - 1].speakerName,
+              text: transcription.utterances[idx - 1].text,
+            }
+          : null;
+
+      return {
+        utteranceIndex: idx,
+        speakerId: utterance.speakerId,
+        speakerName: utterance.speakerName,
+        text: utterance.text,
+        previousUtterance,
+        intent: llm?.intent ?? 'その他',
+        topic: llm?.topic ?? '',
+      };
+    });
+
+    return { transcriptionId, results };
   }
 }

--- a/backend/src/interview/types/interview.types.ts
+++ b/backend/src/interview/types/interview.types.ts
@@ -25,3 +25,32 @@ export interface InterviewAnalysis {
   /** 作成日時（ISO 8601） */
   createdAt: string;
 }
+
+/** 発言の文脈分析結果（1つの発話に対する分析） */
+export interface UtteranceContextResult {
+  /** 発話インデックス */
+  utteranceIndex: number;
+  /** 話者ID */
+  speakerId: string;
+  /** 話者名 */
+  speakerName: string;
+  /** 発話テキスト */
+  text: string;
+  /** 直前の発話（データから抽出） */
+  previousUtterance: {
+    speakerName: string;
+    text: string;
+  } | null;
+  /** 発言の意図（LLMから） */
+  intent: string;
+  /** 話題（LLMから） */
+  topic: string;
+}
+
+/** 発言の文脈分析レスポンス全体 */
+export interface ContextAnalysisResponse {
+  /** 文字起こしID */
+  transcriptionId: string;
+  /** 分析結果 */
+  results: UtteranceContextResult[];
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -202,3 +202,27 @@
 .modal-close-button:hover {
   background-color: #2d2d4e;
 }
+
+/* 文脈分析：フローティング分析ボタン */
+.context-floating-button {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #8b5cf6;
+  color: #ffffff;
+  border: none;
+  border-radius: 24px;
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 16px rgba(139, 92, 246, 0.4);
+  z-index: 999;
+  transition: background-color 0.15s, box-shadow 0.15s;
+}
+
+.context-floating-button:hover {
+  background-color: #7c3aed;
+  box-shadow: 0 6px 20px rgba(139, 92, 246, 0.5);
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,9 +6,14 @@ import { SpeakerNameEditor } from './components/SpeakerNameEditor';
 import { AudioPlayer } from './components/AudioPlayer';
 import { KeywordList } from './components/KeywordList';
 import { InterviewPage } from './components/InterviewPage';
-import { transcribeAudio, fetchTranscription } from './api/client';
+import { ContextAnalysisModal } from './components/ContextAnalysisModal';
+import {
+  transcribeAudio,
+  fetchTranscription,
+  analyzeUtteranceContext,
+} from './api/client';
 import { extractKeywords } from './utils/keywords';
-import type { Transcription } from './types';
+import type { Transcription, ContextAnalysisResponse } from './types';
 import './App.css';
 
 type SidebarTab = 'audio' | 'history';
@@ -31,12 +36,65 @@ function App() {
   const [page, setPage] = useState<Page>('main');
   const [filterActive, setFilterActive] = useState(false);
   const [quotaError, setQuotaError] = useState<string | null>(null);
+  const [contextSelectMode, setContextSelectMode] = useState(false);
+  const [selectedUtteranceIndices, setSelectedUtteranceIndices] = useState<
+    Set<number>
+  >(new Set());
+  const [contextAnalysis, setContextAnalysis] =
+    useState<ContextAnalysisResponse | null>(null);
+  const [contextAnalyzing, setContextAnalyzing] = useState(false);
 
   /** 文字起こしテキストからキーワードを抽出（メモ化） */
   const keywords = useMemo(
     () => (transcription ? extractKeywords(transcription.fullText) : []),
     [transcription],
   );
+
+  /** 発話選択のトグル */
+  const toggleUtteranceSelection = (index: number) => {
+    setSelectedUtteranceIndices((prev) => {
+      const next = new Set(prev);
+      if (next.has(index)) {
+        next.delete(index);
+      } else {
+        next.add(index);
+      }
+      return next;
+    });
+  };
+
+  /** 文脈選択モードのON/OFF */
+  const toggleContextMode = () => {
+    setContextSelectMode((prev) => {
+      if (prev) {
+        // OFFにするとき選択もクリア
+        setSelectedUtteranceIndices(new Set());
+      }
+      return !prev;
+    });
+  };
+
+  /** 選択された発話の文脈を分析 */
+  const handleAnalyzeContext = async () => {
+    if (!transcription || selectedUtteranceIndices.size === 0) return;
+    setContextAnalyzing(true);
+    try {
+      const result = await analyzeUtteranceContext(
+        transcription.id,
+        Array.from(selectedUtteranceIndices).sort((a, b) => a - b),
+      );
+      setContextAnalysis(result);
+      // 分析完了後、選択モードを解除
+      setContextSelectMode(false);
+      setSelectedUtteranceIndices(new Set());
+    } catch (e) {
+      setError(
+        e instanceof Error ? e.message : '文脈分析に失敗しました',
+      );
+    } finally {
+      setContextAnalyzing(false);
+    }
+  };
 
   /** キーワードのハイライトをトグル */
   const toggleKeywordHighlight = (keyword: string) => {
@@ -200,6 +258,9 @@ function App() {
                 transcription={transcription}
                 highlightedKeywords={highlightedKeywords}
                 filterActive={filterActive}
+                contextSelectMode={contextSelectMode}
+                selectedUtteranceIndices={selectedUtteranceIndices}
+                onToggleUtteranceSelection={toggleUtteranceSelection}
               />
             </>
           )}
@@ -213,10 +274,41 @@ function App() {
               filterActive={filterActive}
               onToggleFilter={() => setFilterActive((prev) => !prev)}
               onNavigateInterview={() => setPage('interview')}
+              onToggleContextMode={toggleContextMode}
+              contextSelectMode={contextSelectMode}
             />
           </aside>
         )}
       </main>
+
+      {/* 文脈分析：フローティング分析ボタン */}
+      {contextSelectMode && selectedUtteranceIndices.size > 0 && (
+        <button
+          className="context-floating-button"
+          onClick={handleAnalyzeContext}
+        >
+          分析する（{selectedUtteranceIndices.size}件）
+        </button>
+      )}
+
+      {/* 文脈分析：ローディング */}
+      {contextAnalyzing && (
+        <div className="modal-overlay">
+          <div className="modal-content">
+            <div className="loading-spinner" />
+            <p>発言の文脈を分析中...</p>
+          </div>
+        </div>
+      )}
+
+      {/* 文脈分析：結果モーダル */}
+      {contextAnalysis && transcription && (
+        <ContextAnalysisModal
+          analysis={contextAnalysis}
+          speakers={transcription.speakers}
+          onClose={() => setContextAnalysis(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,6 @@
 import type {
   AudioFileInfo,
+  ContextAnalysisResponse,
   InterviewAnalysis,
   Transcription,
   TranscriptionSummary,
@@ -205,4 +206,21 @@ export async function updateSpeakerNames(
   }
   const data = await res.json();
   return data.transcription;
+}
+
+/** 発言の文脈を分析 */
+export async function analyzeUtteranceContext(
+  transcriptionId: string,
+  utteranceIndices: number[],
+): Promise<ContextAnalysisResponse> {
+  const res = await fetch(`${BASE_URL}/interview/analyze-context`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transcriptionId, utteranceIndices }),
+  });
+  if (!res.ok) {
+    throw new Error(`文脈分析に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.analysis;
 }

--- a/frontend/src/components/ContextAnalysisModal.css
+++ b/frontend/src/components/ContextAnalysisModal.css
@@ -1,0 +1,161 @@
+/* 文脈分析モーダル（幅広） */
+.context-modal {
+  max-width: 720px;
+  text-align: left;
+}
+
+.context-modal-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.context-modal-header h3 {
+  font-size: 1.1rem;
+  color: #1f2937;
+  margin: 0;
+}
+
+.context-modal-count {
+  font-size: 0.75rem;
+  color: #8b5cf6;
+  background-color: #f5f3ff;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+/* 結果カードリスト */
+.context-results {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 60vh;
+  overflow-y: auto;
+  margin-bottom: 1.25rem;
+}
+
+/* 各カード */
+.context-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  background-color: #fafafa;
+}
+
+.context-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.context-speaker-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+/* 意図バッジ共通 */
+.context-intent-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+
+/* 意図別カラー */
+.intent-question {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.intent-answer {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.intent-agree {
+  background-color: #d1fae5;
+  color: #065f46;
+}
+
+.intent-disagree {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.intent-supplement {
+  background-color: #fef9c3;
+  color: #854d0e;
+}
+
+.intent-proposal {
+  background-color: #f3e8ff;
+  color: #6b21a8;
+}
+
+.intent-explain {
+  background-color: #e0f2fe;
+  color: #0c4a6e;
+}
+
+.intent-other {
+  background-color: #f3f4f6;
+  color: #4b5563;
+}
+
+/* 発話テキスト */
+.context-utterance-text {
+  font-size: 0.9rem;
+  color: #1f2937;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+/* 直前の発言 */
+.context-previous {
+  font-size: 0.78rem;
+  color: #6b7280;
+  background-color: #f3f4f6;
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+  margin-bottom: 0.5rem;
+  line-height: 1.5;
+}
+
+.context-previous-label {
+  font-weight: 600;
+  margin-right: 0.3rem;
+}
+
+.context-previous-speaker {
+  font-weight: 600;
+  margin-right: 0.25rem;
+}
+
+.context-previous-text {
+  color: #4b5563;
+}
+
+/* 話題 */
+.context-topic {
+  font-size: 0.78rem;
+  color: #6b7280;
+}
+
+.context-topic-label {
+  font-weight: 600;
+  margin-right: 0.3rem;
+}
+
+.context-topic-text {
+  color: #8b5cf6;
+  font-weight: 500;
+}
+
+/* フッター */
+.context-modal-footer {
+  text-align: center;
+}

--- a/frontend/src/components/ContextAnalysisModal.tsx
+++ b/frontend/src/components/ContextAnalysisModal.tsx
@@ -1,0 +1,100 @@
+import type { ContextAnalysisResponse, Speaker } from '../types';
+import './ContextAnalysisModal.css';
+
+interface Props {
+  analysis: ContextAnalysisResponse;
+  speakers: Speaker[];
+  onClose: () => void;
+}
+
+/** 意図に応じたバッジCSSクラスを返す */
+function getIntentClass(intent: string): string {
+  switch (intent) {
+    case '質問':
+      return 'intent-question';
+    case '回答':
+      return 'intent-answer';
+    case '同意':
+      return 'intent-agree';
+    case '反論':
+      return 'intent-disagree';
+    case '補足':
+      return 'intent-supplement';
+    case '提案':
+      return 'intent-proposal';
+    case '説明':
+      return 'intent-explain';
+    default:
+      return 'intent-other';
+  }
+}
+
+/** 発言の文脈分析結果モーダル */
+export function ContextAnalysisModal({ analysis, speakers, onClose }: Props) {
+  /** 話者の色を取得 */
+  const getSpeakerColor = (speakerId: string): string => {
+    const speaker = speakers.find((s) => s.id === speakerId);
+    return speaker?.color ?? '#6B7280';
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content context-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="context-modal-header">
+          <h3>発言の文脈分析</h3>
+          <span className="context-modal-count">
+            {analysis.results.length}件の発話
+          </span>
+        </div>
+
+        <div className="context-results">
+          {analysis.results.map((result) => (
+            <div key={result.utteranceIndex} className="context-card">
+              <div className="context-card-header">
+                <span
+                  className="context-speaker-name"
+                  style={{ color: getSpeakerColor(result.speakerId) }}
+                >
+                  {result.speakerName}
+                </span>
+                <span
+                  className={`context-intent-badge ${getIntentClass(result.intent)}`}
+                >
+                  {result.intent}
+                </span>
+              </div>
+
+              <div className="context-topic">
+                <span className="context-topic-label">話題:</span>
+                <span className="context-topic-text">{result.topic}</span>
+              </div>
+
+              <div className="context-utterance-text">{result.text}</div>
+
+              {result.previousUtterance && (
+                <div className="context-previous">
+                  <span className="context-previous-label">直前の発言:</span>
+                  <span className="context-previous-speaker">
+                    {result.previousUtterance.speakerName}
+                  </span>
+                  <span className="context-previous-text">
+                    「{result.previousUtterance.text}」
+                  </span>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+
+        <div className="context-modal-footer">
+          <button className="modal-close-button" onClick={onClose}>
+            閉じる
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/KeywordList.css
+++ b/frontend/src/components/KeywordList.css
@@ -22,6 +22,29 @@
   background-color: #2563eb;
 }
 
+.keyword-context-button {
+  width: 100%;
+  padding: 0.5rem;
+  margin-bottom: 0.75rem;
+  border: 2px solid #8b5cf6;
+  border-radius: 8px;
+  background-color: #ffffff;
+  color: #8b5cf6;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.keyword-context-button:hover {
+  background-color: #f5f3ff;
+}
+
+.keyword-context-button.active {
+  background-color: #8b5cf6;
+  color: #ffffff;
+}
+
 .keyword-list-header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/KeywordList.tsx
+++ b/frontend/src/components/KeywordList.tsx
@@ -9,6 +9,8 @@ interface Props {
   filterActive: boolean;
   onToggleFilter: () => void;
   onNavigateInterview?: () => void;
+  onToggleContextMode?: () => void;
+  contextSelectMode?: boolean;
 }
 
 /** キーワード一覧コンポーネント（右サイドバー） */
@@ -19,6 +21,8 @@ export function KeywordList({
   filterActive,
   onToggleFilter,
   onNavigateInterview,
+  onToggleContextMode,
+  contextSelectMode,
 }: Props) {
   const [filter, setFilter] = useState('');
 
@@ -45,6 +49,14 @@ export function KeywordList({
           onClick={onNavigateInterview}
         >
           会話分析
+        </button>
+      )}
+      {onToggleContextMode && (
+        <button
+          className={`keyword-context-button ${contextSelectMode ? 'active' : ''}`}
+          onClick={onToggleContextMode}
+        >
+          {contextSelectMode ? '発言の文脈（選択中...）' : '発言の文脈'}
         </button>
       )}
       <div className="keyword-list-header">

--- a/frontend/src/components/TranscriptionView.css
+++ b/frontend/src/components/TranscriptionView.css
@@ -39,3 +39,32 @@
   display: flex;
   flex-direction: column;
 }
+
+.utterance-select-wrapper {
+  display: flex;
+  align-items: flex-start;
+}
+
+.utterance-select-wrapper.selectable {
+  gap: 0.75rem;
+  padding: 0.25rem;
+  border-radius: 8px;
+  transition: background-color 0.15s;
+}
+
+.utterance-select-wrapper.selectable:hover {
+  background-color: #faf5ff;
+}
+
+.utterance-select-wrapper > .utterance-block {
+  flex: 1;
+}
+
+.utterance-checkbox {
+  margin-top: 1rem;
+  flex-shrink: 0;
+  width: 1.1rem;
+  height: 1.1rem;
+  cursor: pointer;
+  accent-color: #8b5cf6;
+}

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -7,10 +7,20 @@ interface Props {
   transcription: Transcription;
   highlightedKeywords: Set<string>;
   filterActive: boolean;
+  contextSelectMode?: boolean;
+  selectedUtteranceIndices?: Set<number>;
+  onToggleUtteranceSelection?: (index: number) => void;
 }
 
 /** 文字起こし結果表示コンポーネント */
-export function TranscriptionView({ transcription, highlightedKeywords, filterActive }: Props) {
+export function TranscriptionView({
+  transcription,
+  highlightedKeywords,
+  filterActive,
+  contextSelectMode,
+  selectedUtteranceIndices,
+  onToggleUtteranceSelection,
+}: Props) {
   const [selectedWords, setSelectedWords] = useState<Set<number>>(new Set());
 
   const toggleWord = (index: number) => {
@@ -91,15 +101,27 @@ export function TranscriptionView({ transcription, highlightedKeywords, filterAc
           );
 
           return (
-            <UtteranceBlock
+            <div
               key={index}
-              utterance={utterance}
-              speaker={speaker}
-              selectedWords={selectedWords}
-              highlightedKeywords={highlightedKeywords}
-              wordIndexOffset={wordOffsets[index]}
-              onWordClick={toggleWord}
-            />
+              className={`utterance-select-wrapper ${contextSelectMode ? 'selectable' : ''}`}
+            >
+              {contextSelectMode && (
+                <input
+                  type="checkbox"
+                  className="utterance-checkbox"
+                  checked={selectedUtteranceIndices?.has(index) ?? false}
+                  onChange={() => onToggleUtteranceSelection?.(index)}
+                />
+              )}
+              <UtteranceBlock
+                utterance={utterance}
+                speaker={speaker}
+                selectedWords={selectedWords}
+                highlightedKeywords={highlightedKeywords}
+                wordIndexOffset={wordOffsets[index]}
+                onWordClick={toggleWord}
+              />
+            </div>
           );
         })}
       </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -73,3 +73,23 @@ export interface InterviewAnalysis {
   results: AnalysisResult[];
   createdAt: string;
 }
+
+/** 発言の文脈分析結果（1つの発話） */
+export interface UtteranceContextResult {
+  utteranceIndex: number;
+  speakerId: string;
+  speakerName: string;
+  text: string;
+  previousUtterance: {
+    speakerName: string;
+    text: string;
+  } | null;
+  intent: string;
+  topic: string;
+}
+
+/** 発言の文脈分析レスポンス */
+export interface ContextAnalysisResponse {
+  transcriptionId: string;
+  results: UtteranceContextResult[];
+}


### PR DESCRIPTION
## Summary
- 文字起こし結果の発話を選択し、Claude APIで文脈（意図・話題）を分析する機能を追加
- 右サイドバーの「発言の文脈」ボタンで選択モードに入り、チェックボックスで発話を選択
- フローティングボタンで分析を実行し、結果をモーダルで表示（話者名・意図バッジ・話題・発話テキスト・直前の発言）

## 変更内容
### バックエンド（5ファイル）
- `claude.service.ts`: 文脈分析プロンプト構築・Claude API呼び出しメソッド追加
- `interview.service.ts`: 文脈分析ビジネスロジック（直前の発話抽出・LLM結果マッピング）
- `interview.controller.ts`: `POST /api/interview/analyze-context` エンドポイント追加
- `dto/analyze-context.dto.ts`: リクエストDTO新規作成
- `types/interview.types.ts`: `UtteranceContextResult`, `ContextAnalysisResponse` 型追加

### フロントエンド（10ファイル）
- `ContextAnalysisModal.tsx/css`: 分析結果モーダル（意図別色分けバッジ付きカード表示）
- `TranscriptionView.tsx/css`: チェックボックス選択モード対応
- `KeywordList.tsx/css`: 「発言の文脈」トグルボタン追加
- `App.tsx/css`: 状態管理・フローティング分析ボタン・ローディング・モーダル統合
- `api/client.ts`: `analyzeUtteranceContext()` API関数追加
- `types/index.ts`: フロントエンド型定義追加

## Test plan
- [x] 「発言の文脈」ボタンを押して選択モードに切り替わることを確認
- [x] チェックボックスで複数の発話を選択できることを確認
- [x] フローティングボタン「分析する（N件）」が表示されることを確認
- [x] 分析実行後、モーダルに意図バッジ・話題・発話テキスト・直前の発言が表示されることを確認
- [x] モーダルを閉じた後、選択モードが解除されていることを確認
- [x] TypeScriptビルドがエラーなく通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)