### PR TITLE
fix: サイドバー固定・音声プレーヤー固定レイアウト

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,5 @@
 .app {
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }
@@ -70,8 +70,21 @@
 
 .app-content {
   flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-content-fixed {
+  flex-shrink: 0;
+  padding: 1rem 2rem 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.app-content-scroll {
+  flex: 1;
   overflow-y: auto;
-  padding: 1.5rem 2rem;
+  padding: 1rem 2rem 1.5rem;
 }
 
 .error-message {
@@ -80,7 +93,7 @@
   color: #991b1b;
   padding: 0.75rem 1rem;
   border-radius: 8px;
-  margin-bottom: 1rem;
+  margin: 1rem 2rem 0;
 }
 
 .loading {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,20 +248,24 @@ function App() {
           )}
           {transcription && !loading && (
             <>
-              <SpeakerNameEditor
-                transcriptionId={transcription.id}
-                speakers={transcription.speakers}
-                onUpdate={setTranscription}
-              />
-              <AudioPlayer fileName={transcription.audioFileName} />
-              <TranscriptionView
-                transcription={transcription}
-                highlightedKeywords={highlightedKeywords}
-                filterActive={filterActive}
-                contextSelectMode={contextSelectMode}
-                selectedUtteranceIndices={selectedUtteranceIndices}
-                onToggleUtteranceSelection={toggleUtteranceSelection}
-              />
+              <div className="app-content-fixed">
+                <AudioPlayer fileName={transcription.audioFileName} />
+              </div>
+              <div className="app-content-scroll">
+                <SpeakerNameEditor
+                  transcriptionId={transcription.id}
+                  speakers={transcription.speakers}
+                  onUpdate={setTranscription}
+                />
+                <TranscriptionView
+                  transcription={transcription}
+                  highlightedKeywords={highlightedKeywords}
+                  filterActive={filterActive}
+                  contextSelectMode={contextSelectMode}
+                  selectedUtteranceIndices={selectedUtteranceIndices}
+                  onToggleUtteranceSelection={toggleUtteranceSelection}
+                />
+              </div>
             </>
           )}
         </section>


### PR DESCRIPTION
## Summary
- 左右サイドバーを画面に固定し、中央コンテンツのみスクロールするよう修正
- 音声プレーヤーを中央コンテンツ上部に固定表示し、話者名・文字起こし結果のみスクロール可能に変更

## 変更内容
- `App.css`: `.app` を `min-height: 100vh` → `height: 100vh` に変更し、3カラムを独立スクロールに
- `App.css`: `.app-content` をフレックスカラムに分割（固定領域 + スクロール領域）
- `App.tsx`: AudioPlayer を `.app-content-fixed` に、SpeakerNameEditor・TranscriptionView を `.app-content-scroll` に配置

## Test plan
- [x] 文字起こし結果を表示し、中央をスクロールしても左右サイドバーが固定されていることを確認
- [x] 音声プレーヤーが中央上部に固定表示されていることを確認
- [x] 話者名・文字起こし結果が音声プレーヤーの下でスクロールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)