### PR TITLE
docs: READMEを整理し、frontend/backendのREADMEを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,6 @@
 - Claude APIのWeb検索ツールを使い、各質問についてWeb検索付きの分析レポートを生成
 - 分析結果はMarkdown→HTMLで見やすく表示、出典URLも表示
 
-## 技術スタック
-
-| レイヤー | 技術 |
-|---------|------|
-| フロントエンド | Vite + React 19 + TypeScript |
-| バックエンド | NestJS 11 + TypeScript |
-| 音声文字起こし | ElevenLabs Scribe v2 API |
-| 会話分析 | Anthropic Claude API（Web検索ツール付き） |
-
 ## ディレクトリ構成
 
 ```
@@ -41,13 +32,15 @@ ai-speak-trace/
 ├── README.md
 ├── CLAUDE.md
 ├── frontend/          # フロントエンド（Vite + React）
+│   └── README.md      # フロントエンドの技術スタック・セットアップ
 └── backend/           # バックエンドAPI（NestJS）
+    ├── README.md      # バックエンドの技術スタック・セットアップ
     └── data/
         ├── outputs/          # 音声ファイルの配置先
         └── transcriptions/   # 文字起こし結果の保存先
 ```
 
-## セットアップ
+## 起動方法
 
 ### 前提条件
 
@@ -56,58 +49,9 @@ ai-speak-trace/
 - ElevenLabs APIキー
 - Anthropic APIキー
 
-### 1. リポジトリのクローン
-
-```bash
-git clone <リポジトリURL>
-cd ai-speak-trace
-```
-
-### 2. 環境変数の設定
-
-```bash
-cp backend/.env.example backend/.env
-```
-
-`backend/.env` に以下を設定します:
-
-```env
-ELEVENLABS_API_KEY=your_elevenlabs_api_key
-ANTHROPIC_API_KEY=your_anthropic_api_key
-STORAGE_TYPE=local
-OUTPUTS_DIR=./data/outputs
-TRANSCRIPTIONS_DIR=./data/transcriptions
-```
-
-本番（S3使用時）は以下を設定:
-
-```env
-STORAGE_TYPE=s3
-S3_BUCKET=your-bucket-name
-S3_AUDIO_PREFIX=outputs/
-S3_TRANSCRIPTIONS_PREFIX=transcriptions/
-AWS_REGION=ap-northeast-1
-```
-
-### 3. バックエンドのセットアップ
-
-```bash
-cd backend
-pnpm install
-```
-
-### 4. フロントエンドのセットアップ
-
-```bash
-cd frontend
-npm install
-```
-
-### 5. 音声ファイルの配置
-
-分析したい音声ファイルを `backend/data/outputs/` フォルダに配置してください。
-
-## 起動方法
+セットアップの詳細は各ディレクトリのREADMEを参照してください。
+- [frontend/README.md](frontend/README.md)
+- [backend/README.md](backend/README.md)
 
 ### 開発モード
 
@@ -129,7 +73,7 @@ npm run dev
 
 ブラウザで http://localhost:5173 にアクセスしてください。
 
-### 本番ビルド
+## 本番ビルド
 
 ```bash
 # バックエンド
@@ -143,41 +87,6 @@ npm run build
 ```
 
 フロントエンドのビルド結果は `frontend/dist/` に出力されます。
-
-### Vercelへのデプロイ
-
-バックエンドとフロントエンドを別々のVercelプロジェクトとしてデプロイします。
-
-#### バックエンド
-
-1. Vercelで新規プロジェクトを作成し、リポジトリを接続
-2. **Root Directory** に `backend` を指定
-3. **Environment Variables** に以下を設定:
-
-| 変数名 | 値 |
-|---|---|
-| `STORAGE_TYPE` | `s3` |
-| `S3_BUCKET` | バケット名 |
-| `S3_AUDIO_PREFIX` | `outputs/` |
-| `S3_TRANSCRIPTIONS_PREFIX` | `transcriptions/` |
-| `AWS_REGION` | `ap-northeast-1` |
-| `AWS_ACCESS_KEY_ID` | AWSアクセスキー |
-| `AWS_SECRET_ACCESS_KEY` | AWSシークレットキー |
-| `ELEVENLABS_API_KEY` | ElevenLabs APIキー |
-| `ANTHROPIC_API_KEY` | Anthropic APIキー |
-| `CORS_ORIGIN` | フロントエンドのURL（例: `https://ai-speak-trace.vercel.app`） |
-
-#### フロントエンド
-
-1. Vercelで新規プロジェクトを作成し、リポジトリを接続
-2. **Root Directory** に `frontend` を指定
-3. **Environment Variables** に以下を設定:
-
-| 変数名 | 値 |
-|---|---|
-| `VITE_API_BASE_URL` | バックエンドのプロダクションURL + `/api`（例: `https://ai-speak-trace-backend.vercel.app/api`） |
-
-> **注意**: `VITE_API_BASE_URL` にはデプロイ固有のURL（ハッシュ入り）ではなく、プロジェクトの固定プロダクションドメインを使用してください。固定ドメインはVercelダッシュボードの Settings → Domains で確認できます。
 
 ## 使い方
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,98 +1,85 @@
-<p align="center">
-  <a href="http://nestjs.com/" target="blank"><img src="https://nestjs.com/img/logo-small.svg" width="120" alt="Nest Logo" /></a>
-</p>
+# AI Speak Trace - Backend
 
-[circleci-image]: https://img.shields.io/circleci/build/github/nestjs/nest/master?token=abc123def456
-[circleci-url]: https://circleci.com/gh/nestjs/nest
+音声ファイルの話者分離・文字起こし・会話分析を行うバックエンドAPIです。
 
-  <p align="center">A progressive <a href="http://nodejs.org" target="_blank">Node.js</a> framework for building efficient and scalable server-side applications.</p>
-    <p align="center">
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/v/@nestjs/core.svg" alt="NPM Version" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/l/@nestjs/core.svg" alt="Package License" /></a>
-<a href="https://www.npmjs.com/~nestjscore" target="_blank"><img src="https://img.shields.io/npm/dm/@nestjs/common.svg" alt="NPM Downloads" /></a>
-<a href="https://circleci.com/gh/nestjs/nest" target="_blank"><img src="https://img.shields.io/circleci/build/github/nestjs/nest/master" alt="CircleCI" /></a>
-<a href="https://discord.gg/G7Qnnhy" target="_blank"><img src="https://img.shields.io/badge/discord-online-brightgreen.svg" alt="Discord"/></a>
-<a href="https://opencollective.com/nest#backer" target="_blank"><img src="https://opencollective.com/nest/backers/badge.svg" alt="Backers on Open Collective" /></a>
-<a href="https://opencollective.com/nest#sponsor" target="_blank"><img src="https://opencollective.com/nest/sponsors/badge.svg" alt="Sponsors on Open Collective" /></a>
-  <a href="https://paypal.me/kamilmysliwiec" target="_blank"><img src="https://img.shields.io/badge/Donate-PayPal-ff3f59.svg" alt="Donate us"/></a>
-    <a href="https://opencollective.com/nest#sponsor"  target="_blank"><img src="https://img.shields.io/badge/Support%20us-Open%20Collective-41B883.svg" alt="Support us"></a>
-  <a href="https://twitter.com/nestframework" target="_blank"><img src="https://img.shields.io/twitter/follow/nestframework.svg?style=social&label=Follow" alt="Follow us on Twitter"></a>
-</p>
-  <!--[![Backers on Open Collective](https://opencollective.com/nest/backers/badge.svg)](https://opencollective.com/nest#backer)
-  [![Sponsors on Open Collective](https://opencollective.com/nest/sponsors/badge.svg)](https://opencollective.com/nest#sponsor)-->
+## 技術スタック
 
-## Description
+| カテゴリ | 技術 | バージョン |
+|---------|------|-----------|
+| フレームワーク | NestJS | 11.x |
+| 言語 | TypeScript | 5.7.x |
+| 音声文字起こし | ElevenLabs Scribe v2 API | - |
+| 会話分析 | Anthropic Claude API | - |
+| ストレージ | ローカルファイル / AWS S3 | - |
+| テスト | Jest | 30.x |
+| リンター | ESLint + Prettier | - |
 
-[Nest](https://github.com/nestjs/nest) framework TypeScript starter repository.
+## セットアップ
 
-## Project setup
+### 依存パッケージのインストール
 
 ```bash
-$ pnpm install
+pnpm install
 ```
 
-## Compile and run the project
+### 環境変数
+
+`backend/.env` に以下を設定してください。
+
+```env
+ELEVENLABS_API_KEY=your_elevenlabs_api_key
+ANTHROPIC_API_KEY=your_anthropic_api_key
+STORAGE_TYPE=local
+OUTPUTS_DIR=./data/outputs
+TRANSCRIPTIONS_DIR=./data/transcriptions
+```
+
+S3ストレージを使用する場合は以下も追加してください。
+
+```env
+STORAGE_TYPE=s3
+S3_BUCKET=your-bucket-name
+S3_AUDIO_PREFIX=outputs/
+S3_TRANSCRIPTIONS_PREFIX=transcriptions/
+AWS_REGION=ap-northeast-1
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+```
+
+### 音声ファイルの配置
+
+分析したい音声ファイルを `data/outputs/` フォルダに配置してください。
+
+### 開発サーバーの起動
 
 ```bash
-# development
-$ pnpm run start
-
-# watch mode
-$ pnpm run start:dev
-
-# production mode
-$ pnpm run start:prod
+pnpm run start:dev
 ```
 
-## Run tests
+http://localhost:3000 で起動します。APIは `/api` プレフィックス付きです。
+
+### ビルド
 
 ```bash
-# unit tests
-$ pnpm run test
-
-# e2e tests
-$ pnpm run test:e2e
-
-# test coverage
-$ pnpm run test:cov
+pnpm run build
+pnpm run start:prod
 ```
 
-## Deployment
-
-When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.
-
-If you are looking for a cloud-based platform to deploy your NestJS application, check out [Mau](https://mau.nestjs.com), our official platform for deploying NestJS applications on AWS. Mau makes deployment straightforward and fast, requiring just a few simple steps:
+### その他のコマンド
 
 ```bash
-$ pnpm install -g @nestjs/mau
-$ mau deploy
+# ユニットテスト
+pnpm run test
+
+# E2Eテスト
+pnpm run test:e2e
+
+# テストカバレッジ
+pnpm run test:cov
+
+# リント
+pnpm run lint
+
+# フォーマット
+pnpm run format
 ```
-
-With Mau, you can deploy your application in just a few clicks, allowing you to focus on building features rather than managing infrastructure.
-
-## Resources
-
-Check out a few resources that may come in handy when working with NestJS:
-
-- Visit the [NestJS Documentation](https://docs.nestjs.com) to learn more about the framework.
-- For questions and support, please visit our [Discord channel](https://discord.gg/G7Qnnhy).
-- To dive deeper and get more hands-on experience, check out our official video [courses](https://courses.nestjs.com/).
-- Deploy your application to AWS with the help of [NestJS Mau](https://mau.nestjs.com) in just a few clicks.
-- Visualize your application graph and interact with the NestJS application in real-time using [NestJS Devtools](https://devtools.nestjs.com).
-- Need help with your project (part-time to full-time)? Check out our official [enterprise support](https://enterprise.nestjs.com).
-- To stay in the loop and get updates, follow us on [X](https://x.com/nestframework) and [LinkedIn](https://linkedin.com/company/nestjs).
-- Looking for a job, or have a job to offer? Check out our official [Jobs board](https://jobs.nestjs.com).
-
-## Support
-
-Nest is an MIT-licensed open source project. It can grow thanks to the sponsors and support by the amazing backers. If you'd like to join them, please [read more here](https://docs.nestjs.com/support).
-
-## Stay in touch
-
-- Author - [Kamil Myśliwiec](https://twitter.com/kammysliwiec)
-- Website - [https://nestjs.com](https://nestjs.com/)
-- Twitter - [@nestframework](https://twitter.com/nestframework)
-
-## License
-
-Nest is [MIT licensed](https://github.com/nestjs/nest/blob/master/LICENSE).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,57 @@
-# React + TypeScript + Vite
+# AI Speak Trace - Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+音声文字起こし結果の閲覧・キーワード分析・会話分析を行うフロントエンドアプリケーションです。
 
-Currently, two official plugins are available:
+## 技術スタック
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+| カテゴリ | 技術 | バージョン |
+|---------|------|-----------|
+| ビルドツール | Vite | 7.x |
+| UIライブラリ | React | 19.x |
+| 言語 | TypeScript | 5.9.x |
+| Markdown変換 | marked | 17.x |
+| リンター | ESLint | 9.x |
 
-## React Compiler
+## セットアップ
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+### 依存パッケージのインストール
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### 環境変数
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+開発時はViteのプロキシ設定により `http://localhost:3000` へ自動的に転送されるため、環境変数の設定は不要です。
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+本番環境ではバックエンドのURLを指定してください。
+
+```env
+VITE_API_BASE_URL=https://your-backend-url.com/api
+```
+
+### 開発サーバーの起動
+
+```bash
+npm run dev
+```
+
+http://localhost:5173 でアクセスできます。
+
+### ビルド
+
+```bash
+npm run build
+```
+
+ビルド結果は `dist/` に出力されます。
+
+### その他のコマンド
+
+```bash
+# ビルド結果のプレビュー
+npm run preview
+
+# リント
+npm run lint
 ```


### PR DESCRIPTION
## Summary
- ルートのREADMEをサービス概要・ディレクトリ構成・起動方法・本番ビルド・使い方に整理
- frontend/README.mdをViteテンプレートからプロジェクト固有の内容（技術スタック・セットアップ）に書き換え
- backend/README.mdをNestJSテンプレートからプロジェクト固有の内容（技術スタック・セットアップ・環境変数）に書き換え

## Test plan
- [x] 各READMEの内容が正しく表示されることを確認
- [x] リンク（frontend/README.md, backend/README.md）が正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)