### PR TITLE
feat: ディープサーチと発言の文脈をベータ機能として設定で切り替え

### DIFF
--- a/backend/src/settings/settings.controller.ts
+++ b/backend/src/settings/settings.controller.ts
@@ -20,6 +20,8 @@ export class SettingsController {
       dataDir?: string;
       elevenlabsApiKey?: string;
       anthropicApiKey?: string;
+      enableDeepSearch?: boolean;
+      enableContextAnalysis?: boolean;
     },
   ) {
     return this.settingsService.updateSettings(dto);

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -8,6 +8,8 @@ interface SettingsFile {
   dataDir?: string;
   elevenlabsApiKey?: string;
   anthropicApiKey?: string;
+  enableDeepSearch?: boolean;
+  enableContextAnalysis?: boolean;
 }
 
 /** API レスポンス用の設定情報 */
@@ -26,6 +28,8 @@ export interface AppSettings {
     elevenlabsApiKey: string;
     anthropicApiKey: string;
   };
+  enableDeepSearch: boolean;
+  enableContextAnalysis: boolean;
 }
 
 @Injectable()
@@ -75,6 +79,8 @@ export class SettingsService {
         anthropicApiKey:
           this.configService.get<string>('ANTHROPIC_API_KEY') || '',
       },
+      enableDeepSearch: this.readSettingsFile().enableDeepSearch ?? false,
+      enableContextAnalysis: this.readSettingsFile().enableContextAnalysis ?? false,
     };
   }
 
@@ -83,6 +89,8 @@ export class SettingsService {
     dataDir?: string;
     elevenlabsApiKey?: string;
     anthropicApiKey?: string;
+    enableDeepSearch?: boolean;
+    enableContextAnalysis?: boolean;
   }): {
     settings: AppSettings;
     restartRequired: boolean;
@@ -104,6 +112,12 @@ export class SettingsService {
       updated.anthropicApiKey = dto.anthropicApiKey;
       process.env.ANTHROPIC_API_KEY = dto.anthropicApiKey;
       apiKeyChanged = true;
+    }
+    if (dto.enableDeepSearch !== undefined) {
+      updated.enableDeepSearch = dto.enableDeepSearch;
+    }
+    if (dto.enableContextAnalysis !== undefined) {
+      updated.enableContextAnalysis = dto.enableContextAnalysis;
     }
 
     this.writeSettingsFile(updated);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { TranscriptionList } from './components/TranscriptionList';
 import { TranscriptionView } from './components/TranscriptionView';
 import { SpeakerNameEditor } from './components/SpeakerNameEditor';
@@ -12,6 +12,7 @@ import SettingsPage from './components/SettingsPage';
 import {
   fetchTranscription,
   analyzeUtteranceContext,
+  fetchSettings,
 } from './api/client';
 import { extractKeywords } from './utils/keywords';
 import type { Transcription, ContextAnalysisResponse } from './types';
@@ -41,6 +42,18 @@ function App() {
   const [contextAnalysis, setContextAnalysis] =
     useState<ContextAnalysisResponse | null>(null);
   const [contextAnalyzing, setContextAnalyzing] = useState(false);
+  const [enableDeepSearch, setEnableDeepSearch] = useState(false);
+  const [enableContextAnalysis, setEnableContextAnalysis] = useState(false);
+
+  /** 起動時にベータ機能の設定を読み込み */
+  useEffect(() => {
+    fetchSettings()
+      .then((s) => {
+        setEnableDeepSearch(s.enableDeepSearch ?? false);
+        setEnableContextAnalysis(s.enableContextAnalysis ?? false);
+      })
+      .catch(() => {});
+  }, []);
 
   /** 文字起こしテキストからキーワードを抽出（メモ化） */
   const keywords = useMemo(
@@ -165,7 +178,16 @@ function App() {
 
   /** 設定ページの場合 */
   if (page === 'settings') {
-    return <SettingsPage onBack={() => setPage('main')} />;
+    return <SettingsPage onBack={() => {
+      // 設定変更を反映するために再読み込み
+      fetchSettings()
+        .then((s) => {
+          setEnableDeepSearch(s.enableDeepSearch ?? false);
+          setEnableContextAnalysis(s.enableContextAnalysis ?? false);
+        })
+        .catch(() => {});
+      setPage('main');
+    }} />;
   }
 
   return (
@@ -265,8 +287,8 @@ function App() {
               filterActive={filterActive}
               onToggleFilter={() => setFilterActive((prev) => !prev)}
               onNavigateInterview={() => setPage('interview')}
-              onNavigateDeepSearch={() => setPage('deep-search')}
-              onToggleContextMode={toggleContextMode}
+              onNavigateDeepSearch={enableDeepSearch ? () => setPage('deep-search') : undefined}
+              onToggleContextMode={enableContextAnalysis ? toggleContextMode : undefined}
               contextSelectMode={contextSelectMode}
             />
           </aside>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -456,6 +456,8 @@ export async function updateSettings(
     dataDir?: string;
     elevenlabsApiKey?: string;
     anthropicApiKey?: string;
+    enableDeepSearch?: boolean;
+    enableContextAnalysis?: boolean;
   },
 ): Promise<{ settings: AppSettings; restartRequired: boolean }> {
   const res = await fetch(`${BASE_URL}/settings`, {

--- a/frontend/src/components/SettingsPage.css
+++ b/frontend/src/components/SettingsPage.css
@@ -237,6 +237,28 @@
   white-space: nowrap;
 }
 
+/* チェックボックス */
+.settings-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #374151;
+  cursor: pointer;
+}
+
+.settings-checkbox-label input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+}
+
+.settings-checkbox-hint {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin: 0.4rem 0 0 1.5rem;
+}
+
 /* 保存ボタン */
 .settings-actions {
   display: flex;

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -18,6 +18,8 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
   const [showSuccess, setShowSuccess] = useState(false);
   const [showElevenlabsKey, setShowElevenlabsKey] = useState(false);
   const [showAnthropicKey, setShowAnthropicKey] = useState(false);
+  const [enableDeepSearch, setEnableDeepSearch] = useState(false);
+  const [enableContextAnalysis, setEnableContextAnalysis] = useState(false);
 
   // 設定を読み込み
   useEffect(() => {
@@ -35,6 +37,8 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
         if (s.apiKeys?.anthropicApiKey) {
           setAnthropicApiKey(s.apiKeys.anthropicApiKey);
         }
+        setEnableDeepSearch(s.enableDeepSearch ?? false);
+        setEnableContextAnalysis(s.enableContextAnalysis ?? false);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -57,6 +61,8 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
     const dto: {
       elevenlabsApiKey?: string;
       anthropicApiKey?: string;
+      enableDeepSearch?: boolean;
+      enableContextAnalysis?: boolean;
     } = {};
 
     if (elevenlabsApiKey !== (settings?.apiKeys?.elevenlabsApiKey || '')) {
@@ -65,6 +71,12 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
     if (anthropicApiKey !== (settings?.apiKeys?.anthropicApiKey || '')) {
       dto.anthropicApiKey = anthropicApiKey;
     }
+    if (enableDeepSearch !== (settings?.enableDeepSearch ?? false)) {
+      dto.enableDeepSearch = enableDeepSearch;
+    }
+    if (enableContextAnalysis !== (settings?.enableContextAnalysis ?? false)) {
+      dto.enableContextAnalysis = enableContextAnalysis;
+    }
 
     try {
       const result = await updateSettings(dto);
@@ -72,6 +84,8 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
       // 保存後に入力値を新しい設定値に同期
       setElevenlabsApiKey(result.settings.apiKeys?.elevenlabsApiKey || '');
       setAnthropicApiKey(result.settings.apiKeys?.anthropicApiKey || '');
+      setEnableDeepSearch(result.settings.enableDeepSearch ?? false);
+      setEnableContextAnalysis(result.settings.enableContextAnalysis ?? false);
       setShowSuccess(true);
     } catch (err: any) {
       setError(err.message);
@@ -83,7 +97,9 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
   // 変更があるか判定
   const hasChanges = settings
     ? elevenlabsApiKey !== (settings.apiKeys?.elevenlabsApiKey || '') ||
-      anthropicApiKey !== (settings.apiKeys?.anthropicApiKey || '')
+      anthropicApiKey !== (settings.apiKeys?.anthropicApiKey || '') ||
+      enableDeepSearch !== (settings.enableDeepSearch ?? false) ||
+      enableContextAnalysis !== (settings.enableContextAnalysis ?? false)
     : false;
 
   // サブディレクトリ（相対パス表示）
@@ -217,6 +233,39 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
                   </div>
                 ))}
               </div>
+            </div>
+
+            {/* ベータ機能 */}
+            <div className="settings-section">
+              <h2>ベータ機能</h2>
+              <label className="settings-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={enableDeepSearch}
+                  onChange={(e) => {
+                    setEnableDeepSearch(e.target.checked);
+                    setShowSuccess(false);
+                  }}
+                />
+                ディープサーチを有効にする
+              </label>
+              <p className="settings-checkbox-hint">
+                有効にすると、右サイドバーに「ディープサーチ」ボタンが表示されます。
+              </p>
+              <label className="settings-checkbox-label" style={{ marginTop: '0.75rem' }}>
+                <input
+                  type="checkbox"
+                  checked={enableContextAnalysis}
+                  onChange={(e) => {
+                    setEnableContextAnalysis(e.target.checked);
+                    setShowSuccess(false);
+                  }}
+                />
+                発言の文脈を有効にする
+              </label>
+              <p className="settings-checkbox-hint">
+                有効にすると、右サイドバーに「発言の文脈」ボタンが表示されます。
+              </p>
             </div>
 
             <div className="settings-actions">

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -150,4 +150,6 @@ export interface AppSettings {
     elevenlabsApiKey: string;
     anthropicApiKey: string;
   };
+  enableDeepSearch: boolean;
+  enableContextAnalysis: boolean;
 }


### PR DESCRIPTION
## Summary
- ディープサーチと発言の文脈をベータ機能としてデフォルト非表示に変更
- 設定画面にベータ機能セクションを追加（個別にON/OFF可能）
- バックエンドの設定ファイル（settings.json）で `enableDeepSearch` / `enableContextAnalysis` を永続化

## Test plan

`npm run dev:app` で起動し、Tauriウィンドウ上で以下を確認:

- [x] デフォルトで右サイドバーに「ディープサーチ」「発言の文脈」ボタンが表示されないこと
- [x] 設定画面に「ベータ機能」セクションと2つのチェックボックスが表示されること
- [x] 各チェックボックスをONにして保存後、メイン画面で対応するボタンが表示されること
- [x] チェックボックスをOFFにして保存後、ボタンが非表示に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)