### PR TITLE
fix: .claude/settings.local.jsonをgitignoreに追加 & devコマンド修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:flexprice.io)",
-      "WebFetch(domain:help.elevenlabs.io)",
-      "WebFetch(domain:api.elevenlabs.io)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env*.local
 node_modules/
 settings.json
+.claude/settings.local.json
 
 # バックエンドデータ（実行時生成）
 backend/data/chunks/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,12 +96,12 @@ ai-speak-trace/
 
 ## PRテストプラン
 
-PRのTest planは以下の形式で記載する。`npm run dev:app` で起動し、Tauriウィンドウ上で確認する。
+PRのTest planは以下の形式で記載する。`npm run dev` で起動し、Tauriウィンドウ上で確認する。
 
 ```markdown
 ## Test plan
 
-`npm run dev:app` で起動し、Tauriウィンドウ上で以下を確認:
+`npm run dev` で起動し、Tauriウィンドウ上で以下を確認:
 
 - [ ] （変更内容に応じた確認項目を記載）
 ```


### PR DESCRIPTION
## Summary
- `.claude/settings.local.json` を `.gitignore` に追加し、Git追跡から除外
- CLAUDE.mdのPRテストプランのコマンドを `npm run dev:app` → `npm run dev` に修正

## Test plan

`npm run dev` で起動し、Tauriウィンドウ上で以下を確認:

- [x] アプリが正常に起動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)