### PR TITLE
feat: 話者フィルター中に直前の発話をポップアップ表示する機能を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   );
   const [page, setPage] = useState<Page>('main');
   const [filterActive, setFilterActive] = useState(false);
+  const [selectedSpeakerId, setSelectedSpeakerId] = useState<string | null>(null);
   const [quotaError, setQuotaError] = useState<string | null>(null);
   const [contextSelectMode, setContextSelectMode] = useState(false);
   const [selectedUtteranceIndices, setSelectedUtteranceIndices] = useState<
@@ -138,6 +139,7 @@ function App() {
     setError(null);
     setHighlightedKeywords(new Set());
     setFilterActive(false);
+    setSelectedSpeakerId(null);
 
     try {
       const result = await fetchTranscription(id);
@@ -342,6 +344,7 @@ function App() {
                   transcription={transcription}
                   highlightedKeywords={highlightedKeywords}
                   filterActive={filterActive}
+                  selectedSpeakerId={selectedSpeakerId}
                   contextSelectMode={contextSelectMode}
                   selectedUtteranceIndices={selectedUtteranceIndices}
                   onToggleUtteranceSelection={toggleUtteranceSelection}
@@ -362,6 +365,9 @@ function App() {
               onNavigateDeepSearch={enableDeepSearch ? () => setPage('deep-search') : undefined}
               onToggleContextMode={enableContextAnalysis ? toggleContextMode : undefined}
               contextSelectMode={contextSelectMode}
+              speakers={transcription.speakers}
+              selectedSpeakerId={selectedSpeakerId}
+              onSpeakerFilterChange={setSelectedSpeakerId}
             />
           </aside>
         )}

--- a/frontend/src/components/JobProgressPage.tsx
+++ b/frontend/src/components/JobProgressPage.tsx
@@ -62,15 +62,18 @@ export function JobProgressPage({
   // ページ表示時にクレジット残量を確認
   useEffect(() => {
     let cancelled = false;
-    setCreditCheckLoading(true);
-    checkCredits()
-      .then((info) => {
+    const loadCredits = async () => {
+      setCreditCheckLoading(true);
+      try {
+        const info = await checkCredits();
         if (!cancelled) setCreditInfo(info);
-      })
-      .catch(() => {})
-      .finally(() => {
+      } catch {
+        // クレジット確認失敗は無視
+      } finally {
         if (!cancelled) setCreditCheckLoading(false);
-      });
+      }
+    };
+    void loadCredits();
     return () => { cancelled = true; };
   }, [jobId]);
 
@@ -89,6 +92,7 @@ export function JobProgressPage({
           );
         });
     }
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- job全体ではなくstatus/transcriptionIdの変化のみ監視
   }, [job?.status, job?.transcriptionId]);
 
   /** トップに戻るボタンクリック時 */

--- a/frontend/src/components/KeywordList.css
+++ b/frontend/src/components/KeywordList.css
@@ -63,6 +63,35 @@
   color: #ffffff;
 }
 
+.speaker-filter {
+  margin-bottom: 0.75rem;
+}
+
+.speaker-filter-label {
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  margin-bottom: 0.25rem;
+}
+
+.speaker-filter-select {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  background-color: #ffffff;
+  cursor: pointer;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.speaker-filter-select:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
 .keyword-list-header {
   display: flex;
   align-items: center;

--- a/frontend/src/components/KeywordList.tsx
+++ b/frontend/src/components/KeywordList.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { Keyword } from '../types';
+import type { Keyword, Speaker } from '../types';
 import './KeywordList.css';
 
 interface Props {
@@ -12,6 +12,9 @@ interface Props {
   onNavigateDeepSearch?: () => void;
   onToggleContextMode?: () => void;
   contextSelectMode?: boolean;
+  speakers?: Speaker[];
+  selectedSpeakerId: string | null;
+  onSpeakerFilterChange: (speakerId: string | null) => void;
 }
 
 /** キーワード一覧コンポーネント（右サイドバー） */
@@ -25,6 +28,9 @@ export function KeywordList({
   onNavigateDeepSearch,
   onToggleContextMode,
   contextSelectMode,
+  speakers,
+  selectedSpeakerId,
+  onSpeakerFilterChange,
 }: Props) {
   const [filter, setFilter] = useState('');
 
@@ -68,6 +74,21 @@ export function KeywordList({
         >
           {contextSelectMode ? '発言の文脈（選択中...）' : '発言の文脈'}
         </button>
+      )}
+      {speakers && speakers.length > 0 && (
+        <div className="speaker-filter">
+          <label className="speaker-filter-label">話者フィルター</label>
+          <select
+            className="speaker-filter-select"
+            value={selectedSpeakerId ?? ''}
+            onChange={(e) => onSpeakerFilterChange(e.target.value || null)}
+          >
+            <option value="">全員</option>
+            {speakers.map((s) => (
+              <option key={s.id} value={s.id}>{s.name}</option>
+            ))}
+          </select>
+        </div>
       )}
       <div className="keyword-list-header">
         <h2>キーワード</h2>

--- a/frontend/src/components/PreviousUtterancePopup.css
+++ b/frontend/src/components/PreviousUtterancePopup.css
@@ -1,0 +1,95 @@
+/** 直前発話ポップアップのオーバーレイ */
+.previous-utterance-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/** 直前発話ポップアップ本体 */
+.previous-utterance-popup {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  max-width: 520px;
+  width: 90%;
+  padding: 1.25rem;
+  position: relative;
+}
+
+.previous-utterance-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.previous-utterance-popup-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.previous-utterance-popup-close {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.previous-utterance-popup-close:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.previous-utterance-popup-content {
+  padding: 0.75rem 1rem;
+  border-left: 4px solid #6b7280;
+  border-radius: 0 8px 8px 0;
+  background-color: #f9fafb;
+}
+
+.previous-utterance-popup-speaker {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.previous-utterance-popup-speaker-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.previous-utterance-popup-time {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.previous-utterance-popup-text {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: #374151;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/** クリック可能な発話ブロック */
+.utterance-block.clickable {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.utterance-block.clickable:hover {
+  background-color: #f9fafb;
+}

--- a/frontend/src/components/PreviousUtterancePopup.tsx
+++ b/frontend/src/components/PreviousUtterancePopup.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import type { Speaker, Utterance } from '../types';
+import './PreviousUtterancePopup.css';
+
+interface Props {
+  utterance: Utterance;
+  speaker: Speaker | undefined;
+  onClose: () => void;
+}
+
+/** 時間を mm:ss 形式に変換 */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** 直前の発話をポップアップ表示するコンポーネント */
+export function PreviousUtterancePopup({ utterance, speaker, onClose }: Props) {
+  const textRef = useRef<HTMLDivElement>(null);
+  const borderColor = speaker?.color ?? '#6B7280';
+
+  // マウント時にテキスト領域を一番下までスクロール
+  useEffect(() => {
+    if (textRef.current) {
+      textRef.current.scrollTop = textRef.current.scrollHeight;
+    }
+  }, [utterance]);
+
+  return (
+    <div className="previous-utterance-overlay" onClick={onClose}>
+      <div
+        className="previous-utterance-popup"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="previous-utterance-popup-header">
+          <span className="previous-utterance-popup-title">直前の発話</span>
+          <button className="previous-utterance-popup-close" onClick={onClose}>
+            &times;
+          </button>
+        </div>
+        <div
+          className="previous-utterance-popup-content"
+          style={{ borderLeftColor: borderColor }}
+        >
+          <div className="previous-utterance-popup-speaker">
+            <span
+              className="previous-utterance-popup-speaker-name"
+              style={{ color: borderColor }}
+            >
+              {utterance.speakerName}
+            </span>
+            <span className="previous-utterance-popup-time">
+              {formatTime(utterance.start)} - {formatTime(utterance.end)}
+            </span>
+          </div>
+          <div className="previous-utterance-popup-text" ref={textRef}>
+            {utterance.text}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -87,8 +87,8 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
       setEnableDeepSearch(result.settings.enableDeepSearch ?? false);
       setEnableContextAnalysis(result.settings.enableContextAnalysis ?? false);
       setShowSuccess(true);
-    } catch (err: any) {
-      setError(err.message);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : '保存に失敗しました');
     } finally {
       setSaving(false);
     }

--- a/frontend/src/components/TranscribePage.tsx
+++ b/frontend/src/components/TranscribePage.tsx
@@ -193,7 +193,7 @@ export function TranscribePage({
       if (typeof selected === 'string') {
         filePath = selected;
       } else if (typeof selected === 'object' && selected !== null && 'path' in selected) {
-        filePath = (selected as any).path;
+        filePath = (selected as { path: string }).path;
       } else {
         filePath = String(selected);
       }

--- a/frontend/src/components/TranscriptionList.tsx
+++ b/frontend/src/components/TranscriptionList.tsx
@@ -39,7 +39,25 @@ export function TranscriptionList({ selectedId, onSelect, loading }: Props) {
   };
 
   useEffect(() => {
-    loadItems();
+    let cancelled = false;
+    const init = async () => {
+      try {
+        console.log('[TranscriptionList] 履歴一覧の取得を開始');
+        const result = await fetchTranscriptions();
+        if (!cancelled) {
+          console.log('[TranscriptionList] 履歴一覧の取得完了:', result.length, '件');
+          setItems(result);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          const msg = e instanceof Error ? e.message : '取得に失敗しました';
+          console.error('[TranscriptionList] 履歴一覧の取得エラー:', msg, e);
+          setFetchError(msg);
+        }
+      }
+    };
+    void init();
+    return () => { cancelled = true; };
   }, []);
 
   return (

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { UtteranceBlock } from './UtteranceBlock';
+import { PreviousUtterancePopup } from './PreviousUtterancePopup';
 import type { Transcription } from '../types';
 import './TranscriptionView.css';
 
@@ -24,6 +25,8 @@ export function TranscriptionView({
   onToggleUtteranceSelection,
 }: Props) {
   const [selectedWords, setSelectedWords] = useState<Set<number>>(new Set());
+  // 直前発話ポップアップ用の状態（元配列のインデックスを保持）
+  const [previousUtteranceIndex, setPreviousUtteranceIndex] = useState<number | null>(null);
 
   const toggleWord = (index: number) => {
     setSelectedWords((prev) => {
@@ -83,6 +86,25 @@ export function TranscriptionView({
     return offsets;
   }, [transcription.utterances]);
 
+  /** 発話ブロッククリック時：話者フィルター中なら直前の発話をポップアップ表示 */
+  const handleUtteranceClick = (originalIndex: number) => {
+    if (!selectedSpeakerId) return;
+    if (originalIndex <= 0) return;
+    const prevUtterance = transcription.utterances[originalIndex - 1];
+    // 直前が別の話者の場合のみ表示
+    if (prevUtterance && prevUtterance.speakerId !== selectedSpeakerId) {
+      setPreviousUtteranceIndex(originalIndex - 1);
+    }
+  };
+
+  // ポップアップに表示する直前発話データ
+  const popupUtterance = previousUtteranceIndex !== null
+    ? transcription.utterances[previousUtteranceIndex]
+    : null;
+  const popupSpeaker = popupUtterance
+    ? transcription.speakers.find((s) => s.id === popupUtterance.speakerId)
+    : undefined;
+
   return (
     <div className="transcription-view">
       <h3>文字起こし結果</h3>
@@ -128,11 +150,21 @@ export function TranscriptionView({
                 highlightedKeywords={highlightedKeywords}
                 wordIndexOffset={wordOffsets[index]}
                 onWordClick={toggleWord}
+                clickable={!!selectedSpeakerId && index > 0}
+                onBlockClick={() => handleUtteranceClick(index)}
               />
             </div>
           );
         })}
       </div>
+
+      {popupUtterance && (
+        <PreviousUtterancePopup
+          utterance={popupUtterance}
+          speaker={popupSpeaker}
+          onClose={() => setPreviousUtteranceIndex(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -7,6 +7,7 @@ interface Props {
   transcription: Transcription;
   highlightedKeywords: Set<string>;
   filterActive: boolean;
+  selectedSpeakerId?: string | null;
   contextSelectMode?: boolean;
   selectedUtteranceIndices?: Set<number>;
   onToggleUtteranceSelection?: (index: number) => void;
@@ -17,6 +18,7 @@ export function TranscriptionView({
   transcription,
   highlightedKeywords,
   filterActive,
+  selectedSpeakerId,
   contextSelectMode,
   selectedUtteranceIndices,
   onToggleUtteranceSelection,
@@ -37,8 +39,16 @@ export function TranscriptionView({
 
   /** フィルター適用時に表示する発話を絞り込み */
   const displayUtterances = useMemo(() => {
+    // 話者フィルター → キーワードフィルターの順に適用
+    let base = transcription.utterances.map((utterance, i) => ({ utterance, index: i }));
+
+    // 話者フィルター
+    if (selectedSpeakerId) {
+      base = base.filter(({ utterance }) => utterance.speakerId === selectedSpeakerId);
+    }
+
     if (!filterActive || highlightedKeywords.size === 0) {
-      return transcription.utterances.map((utterance, i) => ({ utterance, index: i }));
+      return base;
     }
     // キーワードの各部分（スペース区切り・文字種境界）も展開して照合
     const expandedKeywords: string[] = [];
@@ -56,13 +66,11 @@ export function TranscriptionView({
         }
       }
     }
-    return transcription.utterances
-      .map((utterance, i) => ({ utterance, index: i }))
-      .filter(({ utterance }) => {
-        const text = utterance.text.toLowerCase();
-        return expandedKeywords.some((kw) => text.includes(kw));
-      });
-  }, [transcription.utterances, highlightedKeywords, filterActive]);
+    return base.filter(({ utterance }) => {
+      const text = utterance.text.toLowerCase();
+      return expandedKeywords.some((kw) => text.includes(kw));
+    });
+  }, [transcription.utterances, highlightedKeywords, filterActive, selectedSpeakerId]);
 
   // 各utteranceのword開始インデックスを計算（全utterance分）
   const wordOffsets = useMemo(() => {
@@ -88,7 +96,7 @@ export function TranscriptionView({
         </div>
       )}
 
-      {filterActive && highlightedKeywords.size > 0 && (
+      {(selectedSpeakerId || (filterActive && highlightedKeywords.size > 0)) && (
         <div className="filter-info">
           {displayUtterances.length}件の発話を表示中（全{transcription.utterances.length}件）
         </div>

--- a/frontend/src/components/UtteranceBlock.tsx
+++ b/frontend/src/components/UtteranceBlock.tsx
@@ -9,6 +9,8 @@ interface Props {
   highlightedKeywords: Set<string>;
   wordIndexOffset: number;
   onWordClick: (globalIndex: number) => void;
+  clickable?: boolean;
+  onBlockClick?: () => void;
 }
 
 /** 時間を mm:ss 形式に変換 */
@@ -26,13 +28,16 @@ export function UtteranceBlock({
   highlightedKeywords,
   wordIndexOffset,
   onWordClick,
+  clickable,
+  onBlockClick,
 }: Props) {
   const borderColor = speaker?.color ?? '#6B7280';
 
   return (
     <div
-      className="utterance-block"
+      className={`utterance-block ${clickable ? 'clickable' : ''}`}
       style={{ borderLeftColor: borderColor }}
+      onClick={clickable ? onBlockClick : undefined}
     >
       <div className="utterance-header">
         <span


### PR DESCRIPTION
## Summary

- 話者フィルターで個別の話者を選択中に、発話ブロックをクリックすると直前の別話者の発話をポップアップで確認できる機能を追加
- 長文の発話はスクロール可能で、デフォルトで一番下（最新部分）にスクロールされる
- ポップアップ外クリックまたは×ボタンで閉じられる

## Test plan

`npm run build` でビルドが成功することを確認し、以下を確認:

- [ ] 話者フィルターで特定の話者を選択する
- [ ] フィルター中に発話ブロックをクリックすると直前の発話がポップアップ表示される
- [ ] ポップアップ内の長文がスクロール可能で、デフォルトで下部にスクロールされている
- [ ] ポップアップ外クリックまたは×ボタンで閉じられる
- [ ] 全話者表示時はポップアップが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)