### PR TITLE
feat: 話者フィルター中に直前の発話をポップアップ表示する機能を追加

### DIFF
--- a/frontend/src/components/PreviousUtterancePopup.css
+++ b/frontend/src/components/PreviousUtterancePopup.css
@@ -1,0 +1,95 @@
+/** 直前発話ポップアップのオーバーレイ */
+.previous-utterance-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/** 直前発話ポップアップ本体 */
+.previous-utterance-popup {
+  background-color: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
+  max-width: 520px;
+  width: 90%;
+  padding: 1.25rem;
+  position: relative;
+}
+
+.previous-utterance-popup-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.previous-utterance-popup-title {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+}
+
+.previous-utterance-popup-close {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0.25rem;
+  line-height: 1;
+  border-radius: 4px;
+}
+
+.previous-utterance-popup-close:hover {
+  color: #374151;
+  background-color: #f3f4f6;
+}
+
+.previous-utterance-popup-content {
+  padding: 0.75rem 1rem;
+  border-left: 4px solid #6b7280;
+  border-radius: 0 8px 8px 0;
+  background-color: #f9fafb;
+}
+
+.previous-utterance-popup-speaker {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.previous-utterance-popup-speaker-name {
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.previous-utterance-popup-time {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+
+.previous-utterance-popup-text {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: #374151;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/** クリック可能な発話ブロック */
+.utterance-block.clickable {
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.utterance-block.clickable:hover {
+  background-color: #f9fafb;
+}

--- a/frontend/src/components/PreviousUtterancePopup.tsx
+++ b/frontend/src/components/PreviousUtterancePopup.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import type { Speaker, Utterance } from '../types';
+import './PreviousUtterancePopup.css';
+
+interface Props {
+  utterance: Utterance;
+  speaker: Speaker | undefined;
+  onClose: () => void;
+}
+
+/** 時間を mm:ss 形式に変換 */
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** 直前の発話をポップアップ表示するコンポーネント */
+export function PreviousUtterancePopup({ utterance, speaker, onClose }: Props) {
+  const textRef = useRef<HTMLDivElement>(null);
+  const borderColor = speaker?.color ?? '#6B7280';
+
+  // マウント時にテキスト領域を一番下までスクロール
+  useEffect(() => {
+    if (textRef.current) {
+      textRef.current.scrollTop = textRef.current.scrollHeight;
+    }
+  }, [utterance]);
+
+  return (
+    <div className="previous-utterance-overlay" onClick={onClose}>
+      <div
+        className="previous-utterance-popup"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="previous-utterance-popup-header">
+          <span className="previous-utterance-popup-title">直前の発話</span>
+          <button className="previous-utterance-popup-close" onClick={onClose}>
+            &times;
+          </button>
+        </div>
+        <div
+          className="previous-utterance-popup-content"
+          style={{ borderLeftColor: borderColor }}
+        >
+          <div className="previous-utterance-popup-speaker">
+            <span
+              className="previous-utterance-popup-speaker-name"
+              style={{ color: borderColor }}
+            >
+              {utterance.speakerName}
+            </span>
+            <span className="previous-utterance-popup-time">
+              {formatTime(utterance.start)} - {formatTime(utterance.end)}
+            </span>
+          </div>
+          <div className="previous-utterance-popup-text" ref={textRef}>
+            {utterance.text}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import { UtteranceBlock } from './UtteranceBlock';
+import { PreviousUtterancePopup } from './PreviousUtterancePopup';
 import type { Transcription } from '../types';
 import './TranscriptionView.css';
 
@@ -24,6 +25,8 @@ export function TranscriptionView({
   onToggleUtteranceSelection,
 }: Props) {
   const [selectedWords, setSelectedWords] = useState<Set<number>>(new Set());
+  // 直前発話ポップアップ用の状態（元配列のインデックスを保持）
+  const [previousUtteranceIndex, setPreviousUtteranceIndex] = useState<number | null>(null);
 
   const toggleWord = (index: number) => {
     setSelectedWords((prev) => {
@@ -83,6 +86,25 @@ export function TranscriptionView({
     return offsets;
   }, [transcription.utterances]);
 
+  /** 発話ブロッククリック時：話者フィルター中なら直前の発話をポップアップ表示 */
+  const handleUtteranceClick = (originalIndex: number) => {
+    if (!selectedSpeakerId) return;
+    if (originalIndex <= 0) return;
+    const prevUtterance = transcription.utterances[originalIndex - 1];
+    // 直前が別の話者の場合のみ表示
+    if (prevUtterance && prevUtterance.speakerId !== selectedSpeakerId) {
+      setPreviousUtteranceIndex(originalIndex - 1);
+    }
+  };
+
+  // ポップアップに表示する直前発話データ
+  const popupUtterance = previousUtteranceIndex !== null
+    ? transcription.utterances[previousUtteranceIndex]
+    : null;
+  const popupSpeaker = popupUtterance
+    ? transcription.speakers.find((s) => s.id === popupUtterance.speakerId)
+    : undefined;
+
   return (
     <div className="transcription-view">
       <h3>文字起こし結果</h3>
@@ -128,11 +150,21 @@ export function TranscriptionView({
                 highlightedKeywords={highlightedKeywords}
                 wordIndexOffset={wordOffsets[index]}
                 onWordClick={toggleWord}
+                clickable={!!selectedSpeakerId && index > 0}
+                onBlockClick={() => handleUtteranceClick(index)}
               />
             </div>
           );
         })}
       </div>
+
+      {popupUtterance && (
+        <PreviousUtterancePopup
+          utterance={popupUtterance}
+          speaker={popupSpeaker}
+          onClose={() => setPreviousUtteranceIndex(null)}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/UtteranceBlock.tsx
+++ b/frontend/src/components/UtteranceBlock.tsx
@@ -9,6 +9,8 @@ interface Props {
   highlightedKeywords: Set<string>;
   wordIndexOffset: number;
   onWordClick: (globalIndex: number) => void;
+  clickable?: boolean;
+  onBlockClick?: () => void;
 }
 
 /** 時間を mm:ss 形式に変換 */
@@ -26,13 +28,16 @@ export function UtteranceBlock({
   highlightedKeywords,
   wordIndexOffset,
   onWordClick,
+  clickable,
+  onBlockClick,
 }: Props) {
   const borderColor = speaker?.color ?? '#6B7280';
 
   return (
     <div
-      className="utterance-block"
+      className={`utterance-block ${clickable ? 'clickable' : ''}`}
       style={{ borderLeftColor: borderColor }}
+      onClick={clickable ? onBlockClick : undefined}
     >
       <div className="utterance-header">
         <span


### PR DESCRIPTION
## Summary

- 話者フィルターで個別の話者を選択中に、発話ブロックをクリックすると直前の別話者の発話をポップアップで確認できる機能を追加
- 長文の発話はスクロール可能で、デフォルトで一番下（最新部分）にスクロールされる
- ポップアップ外クリックまたは×ボタンで閉じられる

## Test plan

`npm run build` でビルドが成功することを確認し、以下を確認:

- [x] 話者フィルターで特定の話者を選択する
- [x] フィルター中に発話ブロックをクリックすると直前の発話がポップアップ表示される
- [x] ポップアップ内の長文がスクロール可能で、デフォルトで下部にスクロールされている
- [x] ポップアップ外クリックまたは×ボタンで閉じられる
- [x] 全話者表示時はポップアップが表示されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)