### PR TITLE
feat: 音声再生位置と会話の連動機能を追加

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -121,6 +121,12 @@ function App() {
     }
   };
 
+  /** タイムスタンプクリック時に音声再生位置を変更 */
+  const handleTimeClick = useCallback((startTime: number) => {
+    if (!audioRef.current) return;
+    audioRef.current.currentTime = startTime;
+  }, []);
+
   /** 現在の音声再生位置に対応する発話にジャンプ */
   const handleJumpToUtterance = useCallback(() => {
     if (!transcription || !audioRef.current) return;
@@ -377,6 +383,7 @@ function App() {
                   onToggleUtteranceSelection={toggleUtteranceSelection}
                   scrollToUtteranceIndex={scrollToUtteranceIndex}
                   onScrollComplete={() => setScrollToUtteranceIndex(null)}
+                  onTimeClick={handleTimeClick}
                 />
               </div>
             </>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TranscriptionList } from './components/TranscriptionList';
 import { TranscriptionView } from './components/TranscriptionView';
 import { SpeakerNameEditor } from './components/SpeakerNameEditor';
@@ -51,6 +51,8 @@ function App() {
   const [enableContextAnalysis, setEnableContextAnalysis] = useState(false);
   const [activeJobId, setActiveJobId] = useState<string | null>(null);
   const [resumableJobs, setResumableJobs] = useState<ChunkedJobDetail[]>([]);
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const [scrollToUtteranceIndex, setScrollToUtteranceIndex] = useState<number | null>(null);
 
   /** 起動時にベータ機能の設定を読み込み + 中断ジョブを確認 */
   useEffect(() => {
@@ -118,6 +120,27 @@ function App() {
       setContextAnalyzing(false);
     }
   };
+
+  /** 現在の音声再生位置に対応する発話にジャンプ */
+  const handleJumpToUtterance = useCallback(() => {
+    if (!transcription || !audioRef.current) return;
+    const currentTime = audioRef.current.currentTime;
+    // currentTime以前に開始し、最も近い発話を検索
+    let targetIndex = -1;
+    for (let i = 0; i < transcription.utterances.length; i++) {
+      const u = transcription.utterances[i];
+      if (u.start <= currentTime && currentTime <= u.end) {
+        targetIndex = i;
+        break;
+      }
+      if (u.start <= currentTime) {
+        targetIndex = i;
+      }
+    }
+    if (targetIndex >= 0) {
+      setScrollToUtteranceIndex(targetIndex);
+    }
+  }, [transcription]);
 
   /** キーワードのハイライトをトグル */
   const toggleKeywordHighlight = (keyword: string) => {
@@ -332,7 +355,11 @@ function App() {
           {transcription && !loading && (
             <>
               <div className="app-content-fixed">
-                <AudioPlayer fileName={transcription.audioFileName} />
+                <AudioPlayer
+                  fileName={transcription.audioFileName}
+                  ref={audioRef}
+                  onJumpToUtterance={handleJumpToUtterance}
+                />
               </div>
               <div className="app-content-scroll">
                 <SpeakerNameEditor
@@ -348,6 +375,8 @@ function App() {
                   contextSelectMode={contextSelectMode}
                   selectedUtteranceIndices={selectedUtteranceIndices}
                   onToggleUtteranceSelection={toggleUtteranceSelection}
+                  scrollToUtteranceIndex={scrollToUtteranceIndex}
+                  onScrollComplete={() => setScrollToUtteranceIndex(null)}
                 />
               </div>
             </>

--- a/frontend/src/components/AudioPlayer.css
+++ b/frontend/src/components/AudioPlayer.css
@@ -1,8 +1,30 @@
 .audio-player {
   margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .audio-player audio {
-  width: 100%;
+  flex: 1;
   border-radius: 8px;
+}
+
+.jump-to-utterance-button {
+  flex-shrink: 0;
+  width: 2.2rem;
+  height: 2.2rem;
+  padding: 0;
+  font-size: 1.2rem;
+  line-height: 1;
+  background-color: transparent;
+  border: 1px solid #d1d5db;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+.jump-to-utterance-button:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
 }

--- a/frontend/src/components/AudioPlayer.tsx
+++ b/frontend/src/components/AudioPlayer.tsx
@@ -1,28 +1,40 @@
-import { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { fetchAudioFileUrl } from '../api/client';
 import './AudioPlayer.css';
 
 interface Props {
   fileName: string;
+  onJumpToUtterance?: () => void;
 }
 
 /** 音声再生コンポーネント */
-export function AudioPlayer({ fileName }: Props) {
-  const [audioUrl, setAudioUrl] = useState<string>('');
+export const AudioPlayer = forwardRef<HTMLAudioElement, Props>(
+  function AudioPlayer({ fileName, onJumpToUtterance }, ref) {
+    const [audioUrl, setAudioUrl] = useState<string>('');
 
-  useEffect(() => {
-    fetchAudioFileUrl(fileName).then(setAudioUrl).catch(() => setAudioUrl(''));
-  }, [fileName]);
+    useEffect(() => {
+      fetchAudioFileUrl(fileName).then(setAudioUrl).catch(() => setAudioUrl(''));
+    }, [fileName]);
 
-  if (!audioUrl) {
-    return <div className="audio-player">読み込み中...</div>;
-  }
+    if (!audioUrl) {
+      return <div className="audio-player">読み込み中...</div>;
+    }
 
-  return (
-    <div className="audio-player">
-      <audio controls src={audioUrl}>
-        お使いのブラウザは音声再生に対応していません。
-      </audio>
-    </div>
-  );
-}
+    return (
+      <div className="audio-player">
+        <audio controls src={audioUrl} ref={ref}>
+          お使いのブラウザは音声再生に対応していません。
+        </audio>
+        {onJumpToUtterance && (
+          <button
+            className="jump-to-utterance-button"
+            onClick={onJumpToUtterance}
+            title="現在の再生位置に該当する会話にジャンプします"
+          >
+            🔍
+          </button>
+        )}
+      </div>
+    );
+  },
+);

--- a/frontend/src/components/TranscriptionView.css
+++ b/frontend/src/components/TranscriptionView.css
@@ -68,3 +68,17 @@
   cursor: pointer;
   accent-color: #8b5cf6;
 }
+
+/* 会話ジャンプ時のハイライトアニメーション */
+.utterance-select-wrapper.jump-highlight {
+  animation: jump-highlight-fade 2s ease-out;
+}
+
+@keyframes jump-highlight-fade {
+  0% {
+    background-color: #bfdbfe;
+  }
+  100% {
+    background-color: transparent;
+  }
+}

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { UtteranceBlock } from './UtteranceBlock';
 import { PreviousUtterancePopup } from './PreviousUtterancePopup';
 import type { Transcription } from '../types';
@@ -12,6 +12,10 @@ interface Props {
   contextSelectMode?: boolean;
   selectedUtteranceIndices?: Set<number>;
   onToggleUtteranceSelection?: (index: number) => void;
+  /** スクロール先のutteranceインデックス（元配列のインデックス） */
+  scrollToUtteranceIndex?: number | null;
+  /** スクロール完了後のコールバック */
+  onScrollComplete?: () => void;
 }
 
 /** 文字起こし結果表示コンポーネント */
@@ -23,10 +27,31 @@ export function TranscriptionView({
   contextSelectMode,
   selectedUtteranceIndices,
   onToggleUtteranceSelection,
+  scrollToUtteranceIndex,
+  onScrollComplete,
 }: Props) {
   const [selectedWords, setSelectedWords] = useState<Set<number>>(new Set());
   // 直前発話ポップアップ用の状態（元配列のインデックスを保持）
   const [previousUtteranceIndex, setPreviousUtteranceIndex] = useState<number | null>(null);
+  // 各utterance要素へのref（元配列のインデックスをキーとする）
+  const utteranceRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  // ハイライト中のutteranceインデックス
+  const [highlightedUtteranceIndex, setHighlightedUtteranceIndex] = useState<number | null>(null);
+
+  // スクロール先が指定されたら該当要素にスクロール
+  useEffect(() => {
+    if (scrollToUtteranceIndex == null) return;
+    const el = utteranceRefs.current.get(scrollToUtteranceIndex);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      setHighlightedUtteranceIndex(scrollToUtteranceIndex);
+      // ハイライトを2秒後に消す
+      const timer = setTimeout(() => setHighlightedUtteranceIndex(null), 2000);
+      onScrollComplete?.();
+      return () => clearTimeout(timer);
+    }
+    onScrollComplete?.();
+  }, [scrollToUtteranceIndex]);
 
   const toggleWord = (index: number) => {
     setSelectedWords((prev) => {
@@ -133,7 +158,10 @@ export function TranscriptionView({
           return (
             <div
               key={index}
-              className={`utterance-select-wrapper ${contextSelectMode ? 'selectable' : ''}`}
+              ref={(el) => {
+                if (el) utteranceRefs.current.set(index, el);
+              }}
+              className={`utterance-select-wrapper ${contextSelectMode ? 'selectable' : ''} ${highlightedUtteranceIndex === index ? 'jump-highlight' : ''}`}
             >
               {contextSelectMode && (
                 <input

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -16,6 +16,8 @@ interface Props {
   scrollToUtteranceIndex?: number | null;
   /** スクロール完了後のコールバック */
   onScrollComplete?: () => void;
+  /** タイムスタンプクリック時のコールバック */
+  onTimeClick?: (startTime: number) => void;
 }
 
 /** 文字起こし結果表示コンポーネント */
@@ -29,6 +31,7 @@ export function TranscriptionView({
   onToggleUtteranceSelection,
   scrollToUtteranceIndex,
   onScrollComplete,
+  onTimeClick,
 }: Props) {
   const [selectedWords, setSelectedWords] = useState<Set<number>>(new Set());
   // 直前発話ポップアップ用の状態（元配列のインデックスを保持）
@@ -181,6 +184,7 @@ export function TranscriptionView({
                 onWordClick={toggleWord}
                 clickable={!!selectedSpeakerId && index > 0}
                 onBlockClick={() => handleUtteranceClick(index)}
+                onTimeClick={onTimeClick}
               />
             </div>
           );

--- a/frontend/src/components/TranscriptionView.tsx
+++ b/frontend/src/components/TranscriptionView.tsx
@@ -35,20 +35,21 @@ export function TranscriptionView({
   const [previousUtteranceIndex, setPreviousUtteranceIndex] = useState<number | null>(null);
   // 各utterance要素へのref（元配列のインデックスをキーとする）
   const utteranceRefs = useRef<Map<number, HTMLDivElement>>(new Map());
-  // ハイライト中のutteranceインデックス
-  const [highlightedUtteranceIndex, setHighlightedUtteranceIndex] = useState<number | null>(null);
 
-  // スクロール先が指定されたら該当要素にスクロール
+  // スクロール先が指定されたら該当要素にスクロール＋ハイライト
   useEffect(() => {
     if (scrollToUtteranceIndex == null) return;
     const el = utteranceRefs.current.get(scrollToUtteranceIndex);
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      setHighlightedUtteranceIndex(scrollToUtteranceIndex);
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      el.classList.add('jump-highlight');
       // ハイライトを2秒後に消す
-      const timer = setTimeout(() => setHighlightedUtteranceIndex(null), 2000);
+      const timer = setTimeout(() => el.classList.remove('jump-highlight'), 2000);
       onScrollComplete?.();
-      return () => clearTimeout(timer);
+      return () => {
+        clearTimeout(timer);
+        el.classList.remove('jump-highlight');
+      };
     }
     onScrollComplete?.();
   }, [scrollToUtteranceIndex]);
@@ -161,7 +162,7 @@ export function TranscriptionView({
               ref={(el) => {
                 if (el) utteranceRefs.current.set(index, el);
               }}
-              className={`utterance-select-wrapper ${contextSelectMode ? 'selectable' : ''} ${highlightedUtteranceIndex === index ? 'jump-highlight' : ''}`}
+              className={`utterance-select-wrapper ${contextSelectMode ? 'selectable' : ''}`}
             >
               {contextSelectMode && (
                 <input

--- a/frontend/src/components/UtteranceBlock.css
+++ b/frontend/src/components/UtteranceBlock.css
@@ -24,6 +24,18 @@
   color: #9ca3af;
 }
 
+.utterance-time.clickable-time {
+  cursor: pointer;
+  border-radius: 4px;
+  padding: 0.1rem 0.3rem;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.utterance-time.clickable-time:hover {
+  background-color: #eff6ff;
+  color: #3b82f6;
+}
+
 .utterance-text {
   font-size: 0.95rem;
   line-height: 1.8;

--- a/frontend/src/components/UtteranceBlock.tsx
+++ b/frontend/src/components/UtteranceBlock.tsx
@@ -69,6 +69,7 @@ export function UtteranceBlock({
               isSelected={selectedWords.has(globalIndex)}
               highlightedKeywords={highlightedKeywords}
               onClick={() => onWordClick(globalIndex)}
+              onTimeClick={onTimeClick}
             />
           );
         })}

--- a/frontend/src/components/UtteranceBlock.tsx
+++ b/frontend/src/components/UtteranceBlock.tsx
@@ -11,6 +11,7 @@ interface Props {
   onWordClick: (globalIndex: number) => void;
   clickable?: boolean;
   onBlockClick?: () => void;
+  onTimeClick?: (startTime: number) => void;
 }
 
 /** 時間を mm:ss 形式に変換 */
@@ -30,6 +31,7 @@ export function UtteranceBlock({
   onWordClick,
   clickable,
   onBlockClick,
+  onTimeClick,
 }: Props) {
   const borderColor = speaker?.color ?? '#6B7280';
 
@@ -46,7 +48,14 @@ export function UtteranceBlock({
         >
           {utterance.speakerName}
         </span>
-        <span className="utterance-time">
+        <span
+          className={`utterance-time ${onTimeClick ? 'clickable-time' : ''}`}
+          onClick={onTimeClick ? (e) => {
+            e.stopPropagation();
+            onTimeClick(utterance.start);
+          } : undefined}
+          title={onTimeClick ? 'クリックでこの位置から再生' : undefined}
+        >
           {formatTime(utterance.start)} - {formatTime(utterance.end)}
         </span>
       </div>

--- a/frontend/src/components/WordSpan.tsx
+++ b/frontend/src/components/WordSpan.tsx
@@ -7,6 +7,7 @@ interface Props {
   isSelected: boolean;
   highlightedKeywords: Set<string>;
   onClick: () => void;
+  onTimeClick?: (startTime: number) => void;
 }
 
 /** 時間を mm:ss 形式に変換 */
@@ -72,6 +73,7 @@ export function WordSpan({
   isSelected,
   highlightedKeywords,
   onClick,
+  onTimeClick,
 }: Props) {
   const highlightedContent = useMemo(
     () => renderHighlightedText(word.text, highlightedKeywords),
@@ -93,7 +95,10 @@ export function WordSpan({
   return (
     <span
       className={`word-span ${isSelected ? 'selected' : ''}`}
-      onClick={onClick}
+      onClick={() => {
+        onClick();
+        onTimeClick?.(word.start);
+      }}
       title={`${formatTime(word.start)} - ${formatTime(word.end)}`}
     >
       {highlightedContent}


### PR DESCRIPTION
## Summary

- 🔍ボタンで現在の音声再生位置に該当する発話へ自動スクロール＋ハイライト表示
- 発話のタイムスタンプクリックで音声再生位置をその発話の開始時間に変更
- 単語クリック時にもその単語の開始時間に音声再生位置を変更

## Test plan

`npm run build` でビルドが成功することを確認し、以下を確認:

- [x] 音声を再生→停止後、🔍ボタンを押すと該当する発話までスクロールしハイライトされること
- [x] 発話のタイムスタンプをクリックすると音声再生位置がその発話の開始時間に移動すること
- [x] 単語をクリックすると音声再生位置がその単語の開始時間に移動すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)