### PR TITLE
release/v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,21 @@ xattr -cr /Applications/AI\ Speak\ Trace.app
 
 | キー | 用途 | 取得先 |
 |---|---|---|
-| ElevenLabs APIキー | 音声の文字起こし | https://elevenlabs.io |
-| Anthropic APIキー | 会話分析・質問生成 | https://console.anthropic.com |
+| ElevenLabs | 音声の文字起こし | https://elevenlabs.io/app/developers/api-keys |
+| Anthropic | 会話分析・質問生成 | https://console.anthropic.com |
 
 アプリ内の「設定」画面からAPIキーを設定してください。保存後すぐに反映されるため、アプリの再起動は不要です。
+
+#### ElevenLabs APIキーのアクセス制限
+
+**アクセスが必要な項目:**
+
+| スコープ | 設定 | 理由 |
+|---|---|---|
+| スピーチ to テキスト | アクセス | 音声の文字起こし・ステータス確認に必要 |
+| ユーザー | 読み取り | クレジット残量確認に必要 |
+
+上記以外のスコープ（テキスト読み上げ、サウンドエフェクト、ボイス等）は全て「アクセスなし」に設定してください。
 
 ### 3. 音声ファイルの準備
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,9 +34,9 @@
 - [Messages API リファレンス](https://docs.anthropic.com/ja/api/messages)
 - [Web検索ツール](https://docs.anthropic.com/ja/docs/agents-and-tools/tool-use/web-search-tool)
 
-| エンドポイント | 用途 |
-|---|---|
-| `POST /v1/messages` | 質問生成・会話分析・ディープサーチ（Web検索ツール併用あり） |
+| エンドポイント | 用途 | APIリファレンス |
+|---|---|---|
+| `POST /v1/messages` | 質問生成・会話分析・ディープサーチ（Web検索ツール併用あり） | [Messages](https://docs.anthropic.com/ja/api/messages) |
 
 ## セットアップ
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -34,7 +34,6 @@
 会話分析・質問生成・ディープサーチに使用しています。
 
 - [APIドキュメント](https://docs.anthropic.com/ja/docs/welcome)
-- [Messages API リファレンス](https://docs.anthropic.com/ja/api/messages)
 - [Web検索ツール](https://docs.anthropic.com/ja/docs/agents-and-tools/tool-use/web-search-tool)
 
 | エンドポイント | 用途 | APIリファレンス |

--- a/backend/README.md
+++ b/backend/README.md
@@ -8,7 +8,7 @@
 |---------|------|-----------|
 | フレームワーク | NestJS | 11.x |
 | 言語 | TypeScript | 5.7.x |
-| 音声文字起こし | [ElevenLabs Scribe v2](https://elevenlabs.io/docs/capabilities/speech-to-text) API | - |
+| 音声文字起こし | [ElevenLabs Scribe v2](https://elevenlabs.io/docs/overview/capabilities/speech-to-text) API | - |
 | 会話分析 | [Claude API](https://docs.anthropic.com/ja/docs/welcome)（[Anthropic](https://www.anthropic.com/)） | - |
 | ストレージ | ローカルファイル | - |
 | テスト | Jest | 30.x |
@@ -19,6 +19,9 @@
 ### ElevenLabs API
 
 音声ファイルの文字起こしに使用しています。
+
+- [APIクイックスタート](https://elevenlabs.io/docs/eleven-api/quickstart)
+- [Speech to Text ドキュメント](https://elevenlabs.io/docs/overview/capabilities/speech-to-text)
 
 | エンドポイント | 用途 | APIリファレンス |
 |---|---|---|

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,30 @@
 | テスト | Jest | 30.x |
 | リンター | ESLint + Prettier | - |
 
+## 利用しているAPI
+
+### ElevenLabs API
+
+音声ファイルの文字起こしに使用しています。
+
+| エンドポイント | 用途 | APIリファレンス |
+|---|---|---|
+| `POST /v1/speech-to-text` | 音声ファイルの文字起こし（Scribe v2） | [Convert](https://elevenlabs.io/docs/api-reference/speech-to-text/convert) |
+| `GET /v1/user/subscription` | クレジット残量の確認 | [Subscription](https://elevenlabs.io/docs/api-reference/user/subscription) |
+| `GET /v1/speech-to-text/transcripts/{id}` | 文字起こしステータスの確認 | [Get Transcript](https://elevenlabs.io/docs/api-reference/speech-to-text/get) |
+
+### Claude API（Anthropic）
+
+会話分析・質問生成・ディープサーチに使用しています。
+
+- [APIドキュメント](https://docs.anthropic.com/ja/docs/welcome)
+- [Messages API リファレンス](https://docs.anthropic.com/ja/api/messages)
+- [Web検索ツール](https://docs.anthropic.com/ja/docs/agents-and-tools/tool-use/web-search-tool)
+
+| エンドポイント | 用途 |
+|---|---|
+| `POST /v1/messages` | 質問生成・会話分析・ディープサーチ（Web検索ツール併用あり） |
+
 ## セットアップ
 
 ### 依存パッケージのインストール


### PR DESCRIPTION
## Summary
- README.mdにElevenLabs APIキーのスコープ制限設定ガイドを追加
- backend/README.mdに利用しているAPI（ElevenLabs・Claude）のエンドポイント一覧とAPIリファレンスリンクを追加
- 技術スタックテーブルのリンク切れを修正

## Test plan

### CI自動チェック（PRのChecksタブで確認）
- [x] `backend-test` がパスしていること
- [x] `frontend-test` がパスしていること

### 手動確認
- [x] `npm run build` でビルドが成功すること
- [x] リリースに含まれる変更が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)