### PR TITLE
fix: 3人以上の話者分離対応と複数話者の表示改善

### DIFF
--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -80,7 +80,8 @@ export class SettingsService {
           this.configService.get<string>('ANTHROPIC_API_KEY') || '',
       },
       enableDeepSearch: this.readSettingsFile().enableDeepSearch ?? false,
-      enableContextAnalysis: this.readSettingsFile().enableContextAnalysis ?? false,
+      enableContextAnalysis:
+        this.readSettingsFile().enableContextAnalysis ?? false,
     };
   }
 
@@ -165,8 +166,7 @@ export class SettingsService {
    */
   static loadSettingsIntoEnv(): void {
     const settingsPath =
-      process.env.SETTINGS_FILE ||
-      path.join(process.cwd(), 'settings.json');
+      process.env.SETTINGS_FILE || path.join(process.cwd(), 'settings.json');
 
     try {
       if (!fs.existsSync(settingsPath)) return;
@@ -182,14 +182,18 @@ export class SettingsService {
         );
       }
 
-      // APIキーをsettings.jsonから環境変数にマージ
-      if (settings.elevenlabsApiKey && !process.env.ELEVENLABS_API_KEY) {
+      // APIキーはsettings.json（アプリの設定画面）の値を常に優先する
+      if (settings.elevenlabsApiKey) {
         process.env.ELEVENLABS_API_KEY = settings.elevenlabsApiKey;
-        console.log('[Settings] ELEVENLABS_API_KEY を settings.json から読み込み');
+        console.log(
+          '[Settings] ELEVENLABS_API_KEY を settings.json から読み込み',
+        );
       }
-      if (settings.anthropicApiKey && !process.env.ANTHROPIC_API_KEY) {
+      if (settings.anthropicApiKey) {
         process.env.ANTHROPIC_API_KEY = settings.anthropicApiKey;
-        console.log('[Settings] ANTHROPIC_API_KEY を settings.json から読み込み');
+        console.log(
+          '[Settings] ANTHROPIC_API_KEY を settings.json から読み込み',
+        );
       }
     } catch (error) {
       console.warn(`[Settings] 設定ファイルの読み込みに失敗: ${error}`);

--- a/backend/src/transcription/chunked-transcription.utils.ts
+++ b/backend/src/transcription/chunked-transcription.utils.ts
@@ -90,10 +90,12 @@ export function resolveSpeakerMapping(
   const gapSec = currentFirstTime - prevLastTime;
 
   if (gapSec < 5) {
+    // 前チャンクの支配的話者が現チャンクでは別IDに割り当てられている
+    // → currentDominantSpeaker と prevDominantSpeaker をswapする
     return swapSpeakerIds(
       currentChunkWords,
-      currentSpeakers[0],
-      currentSpeakers[1],
+      currentDominantSpeaker,
+      prevDominantSpeaker,
     );
   }
 

--- a/backend/src/transcription/elevenlabs.service.ts
+++ b/backend/src/transcription/elevenlabs.service.ts
@@ -1,5 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ElevenLabsCreditInfo, ElevenLabsResponse } from './types/elevenlabs.types';
+import {
+  ElevenLabsCreditInfo,
+  ElevenLabsResponse,
+} from './types/elevenlabs.types';
 
 /** 全体のタイムアウト（ミリ秒）: 30分
  * ElevenLabsはリアルタイムの20〜50倍速で処理するため、
@@ -47,7 +50,6 @@ export class ElevenLabsService {
     form.append('model_id', 'scribe_v2');
     form.append('language_code', 'ja');
     form.append('diarize', 'true');
-    form.append('num_speakers', '2');
     form.append('timestamps_granularity', 'word');
     form.append('tag_audio_events', 'true');
 
@@ -55,7 +57,9 @@ export class ElevenLabsService {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
-    this.logger.log(`ElevenLabs API リクエスト送信 (タイムアウト: ${TIMEOUT_MS / 60000}分)`);
+    this.logger.log(
+      `ElevenLabs API リクエスト送信 (タイムアウト: ${TIMEOUT_MS / 60000}分)`,
+    );
 
     let response: Response;
     try {
@@ -69,7 +73,9 @@ export class ElevenLabsService {
       clearTimeout(timeoutId);
       // AbortErrorはタイムアウトとして処理
       if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-        this.logger.error(`文字起こしタイムアウト: ${TIMEOUT_MS / 60000}分を超過 (${fileName})`);
+        this.logger.error(
+          `文字起こしタイムアウト: ${TIMEOUT_MS / 60000}分を超過 (${fileName})`,
+        );
         const error = new Error(
           `文字起こしがタイムアウトしました（${TIMEOUT_MS / 60000}分経過）。音声ファイルが大きすぎる可能性があります。`,
         );
@@ -86,7 +92,9 @@ export class ElevenLabsService {
       clearTimeout(timeoutId);
     }
 
-    this.logger.log(`ElevenLabs API レスポンス受信: status=${response.status} (${elapsedSec()}秒)`);
+    this.logger.log(
+      `ElevenLabs API レスポンス受信: status=${response.status} (${elapsedSec()}秒)`,
+    );
 
     if (!response.ok) {
       await this.handleErrorResponse(response);
@@ -127,7 +135,11 @@ export class ElevenLabsService {
       );
     }
 
-    const data = await response.json();
+    const data = (await response.json()) as {
+      character_count?: number;
+      character_limit?: number;
+      next_character_count_reset_unix?: number;
+    };
     const characterCount: number = data.character_count ?? 0;
     const characterLimit: number = data.character_limit ?? 0;
     const nextResetUnix: number = data.next_character_count_reset_unix ?? 0;
@@ -145,15 +157,15 @@ export class ElevenLabsService {
   /** エラーレスポンスを解析してスローする */
   private async handleErrorResponse(response: Response): Promise<never> {
     const errorBody = await response.text();
-    this.logger.error(
-      `ElevenLabs API エラー: ${response.status} ${errorBody}`,
-    );
+    this.logger.error(`ElevenLabs API エラー: ${response.status} ${errorBody}`);
 
     // クォータ超過をチェック（401レスポンスにquota_exceededが含まれる場合）
     if (errorBody.includes('quota_exceeded')) {
       let detail = '';
       try {
-        const parsed = JSON.parse(errorBody);
+        const parsed = JSON.parse(errorBody) as {
+          detail?: { message?: string };
+        };
         const msg: string = parsed?.detail?.message ?? '';
         const quota = msg.match(/quota of (\d+)/)?.[1];
         const remaining = msg.match(/have (\d+) credits remaining/)?.[1];
@@ -214,17 +226,20 @@ export class ElevenLabsService {
 
       if (response.ok) {
         // 200: 完了（トランスクリプトデータを取得できた）
-        const data = await response.json();
+        const data = (await response.json()) as Record<string, unknown>;
         this.logger.log(`文字起こし完了: ${transcriptionId}`);
         return { status: 'completed', data };
       }
 
       if (response.status === 404) {
         // 404: トランスクリプトが存在しない（削除済みまたは無効なID）
-        this.logger.warn(`トランスクリプトが見つかりません: ${transcriptionId}`);
+        this.logger.warn(
+          `トランスクリプトが見つかりません: ${transcriptionId}`,
+        );
         return {
           status: 'error',
-          error_message: 'トランスクリプトが見つかりません（削除済みまたは無効なID）',
+          error_message:
+            'トランスクリプトが見つかりません（削除済みまたは無効なID）',
         };
       }
 
@@ -248,7 +263,8 @@ export class ElevenLabsService {
         error_message: `ElevenLabs API エラー (${response.status})`,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       this.logger.error(`文字起こしステータス確認失敗: ${errorMessage}`);
       return {
         status: 'error',

--- a/backend/src/transcription/transcription.utils.spec.ts
+++ b/backend/src/transcription/transcription.utils.spec.ts
@@ -4,6 +4,7 @@ import {
   buildSpeakers,
   groupWordsIntoUtterances,
   convertWords,
+  generateSpeakerName,
 } from './transcription.utils';
 import { ElevenLabsWord } from './types/elevenlabs.types';
 
@@ -153,6 +154,23 @@ describe('mergeWordsIntoPhrases', () => {
   });
 });
 
+describe('generateSpeakerName', () => {
+  it('インデックス0〜2でA〜Cさんを返す', () => {
+    expect(generateSpeakerName(0)).toBe('Aさん');
+    expect(generateSpeakerName(1)).toBe('Bさん');
+    expect(generateSpeakerName(2)).toBe('Cさん');
+  });
+
+  it('インデックス25でZさんを返す', () => {
+    expect(generateSpeakerName(25)).toBe('Zさん');
+  });
+
+  it('インデックス26以上でAA、ABさんを返す', () => {
+    expect(generateSpeakerName(26)).toBe('AAさん');
+    expect(generateSpeakerName(27)).toBe('ABさん');
+  });
+});
+
 describe('buildSpeakers', () => {
   it('空配列から空の話者リストを返す', () => {
     expect(buildSpeakers([])).toEqual([]);
@@ -182,7 +200,7 @@ describe('buildSpeakers', () => {
     expect(speakers[1].color).toBe('#EF4444');
   });
 
-  it('3人以上の話者にはフォールバック名・色を割り当てる', () => {
+  it('3人以上の話者にもアルファベット順の名前を割り当てる', () => {
     const words = [
       word('あ', 0, 0.1, 'speaker_0'),
       word('い', 0.1, 0.2, 'speaker_1'),
@@ -190,7 +208,7 @@ describe('buildSpeakers', () => {
     ];
     const speakers = buildSpeakers(words);
     expect(speakers).toHaveLength(3);
-    expect(speakers[2].name).toBe('話者3');
+    expect(speakers[2].name).toBe('Cさん');
     expect(speakers[2].color).toBe('#6B7280');
   });
 

--- a/backend/src/transcription/transcription.utils.spec.ts
+++ b/backend/src/transcription/transcription.utils.spec.ts
@@ -202,7 +202,7 @@ describe('buildSpeakers', () => {
     const speakers = buildSpeakers(words);
     expect(speakers).toHaveLength(3);
     expect(speakers[2].name).toBe('Cさん');
-    expect(speakers[2].color).toBe('#6B7280');
+    expect(speakers[2].color).toBe('#10B981');
   });
 
   it('話者IDをソート順で返す', () => {

--- a/backend/src/transcription/transcription.utils.spec.ts
+++ b/backend/src/transcription/transcription.utils.spec.ts
@@ -154,20 +154,18 @@ describe('mergeWordsIntoPhrases', () => {
   });
 });
 
+// ElevenLabs Scribe v2の話者分離は最大32人まで対応
+// @see https://elevenlabs.io/docs/capabilities/speech-to-text
 describe('generateSpeakerName', () => {
-  it('インデックス0〜2でA〜Cさんを返す', () => {
+  it('インデックスからアルファベット順の話者名を返す', () => {
     expect(generateSpeakerName(0)).toBe('Aさん');
-    expect(generateSpeakerName(1)).toBe('Bさん');
     expect(generateSpeakerName(2)).toBe('Cさん');
+    expect(generateSpeakerName(4)).toBe('Eさん');
   });
 
-  it('インデックス25でZさんを返す', () => {
+  it('API上限の32人目まで対応する', () => {
     expect(generateSpeakerName(25)).toBe('Zさん');
-  });
-
-  it('インデックス26以上でAA、ABさんを返す', () => {
-    expect(generateSpeakerName(26)).toBe('AAさん');
-    expect(generateSpeakerName(27)).toBe('ABさん');
+    expect(generateSpeakerName(31)).toBe('AFさん');
   });
 });
 

--- a/backend/src/transcription/transcription.utils.spec.ts
+++ b/backend/src/transcription/transcription.utils.spec.ts
@@ -159,13 +159,8 @@ describe('mergeWordsIntoPhrases', () => {
 describe('generateSpeakerName', () => {
   it('インデックスからアルファベット順の話者名を返す', () => {
     expect(generateSpeakerName(0)).toBe('Aさん');
+    expect(generateSpeakerName(1)).toBe('Bさん');
     expect(generateSpeakerName(2)).toBe('Cさん');
-    expect(generateSpeakerName(4)).toBe('Eさん');
-  });
-
-  it('API上限の32人目まで対応する', () => {
-    expect(generateSpeakerName(25)).toBe('Zさん');
-    expect(generateSpeakerName(31)).toBe('AFさん');
   });
 });
 

--- a/backend/src/transcription/transcription.utils.ts
+++ b/backend/src/transcription/transcription.utils.ts
@@ -5,8 +5,16 @@ import {
 } from './types/transcription.types';
 import { ElevenLabsWord } from './types/elevenlabs.types';
 
-/** デフォルトの話者名 */
-export const DEFAULT_SPEAKER_NAMES = ['Aさん', 'Bさん'];
+/** インデックスからアルファベット順の話者名を生成する */
+export function generateSpeakerName(index: number): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  if (index < 26) {
+    return `${chars[index]}さん`;
+  }
+  const first = Math.floor(index / 26) - 1;
+  const second = index % 26;
+  return `${chars[first]}${chars[second]}さん`;
+}
 
 /** 話者の表示色 */
 export const SPEAKER_COLORS = ['#3B82F6', '#EF4444'];
@@ -86,7 +94,7 @@ export function buildSpeakers(words: TranscriptionWord[]): Speaker[] {
   const speakerIds = [...new Set(words.map((w) => w.speakerId))].sort();
   return speakerIds.map((id, index) => ({
     id,
-    name: DEFAULT_SPEAKER_NAMES[index] ?? `話者${index + 1}`,
+    name: generateSpeakerName(index),
     color: SPEAKER_COLORS[index] ?? '#6B7280',
   }));
 }

--- a/backend/src/transcription/transcription.utils.ts
+++ b/backend/src/transcription/transcription.utils.ts
@@ -7,7 +7,8 @@ import { ElevenLabsWord } from './types/elevenlabs.types';
 
 /**
  * インデックスからアルファベット順の話者名を生成する
- * ElevenLabs Scribe v2の話者分離は最大32人まで対応
+ * 0〜25: Aさん〜Zさん、26〜: AAさん、ABさん...
+ * ElevenLabs Scribe v2の話者分離上限は32人
  * @see https://elevenlabs.io/docs/capabilities/speech-to-text
  */
 export function generateSpeakerName(index: number): string {

--- a/backend/src/transcription/transcription.utils.ts
+++ b/backend/src/transcription/transcription.utils.ts
@@ -5,7 +5,11 @@ import {
 } from './types/transcription.types';
 import { ElevenLabsWord } from './types/elevenlabs.types';
 
-/** インデックスからアルファベット順の話者名を生成する */
+/**
+ * インデックスからアルファベット順の話者名を生成する
+ * ElevenLabs Scribe v2の話者分離は最大32人まで対応
+ * @see https://elevenlabs.io/docs/capabilities/speech-to-text
+ */
 export function generateSpeakerName(index: number): string {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   if (index < 26) {

--- a/backend/src/transcription/transcription.utils.ts
+++ b/backend/src/transcription/transcription.utils.ts
@@ -21,8 +21,17 @@ export function generateSpeakerName(index: number): string {
   return `${chars[first]}${chars[second]}さん`;
 }
 
-/** 話者の表示色 */
-export const SPEAKER_COLORS = ['#3B82F6', '#EF4444'];
+/** 話者の表示色（最大32人分、ElevenLabs Scribe v2の話者分離上限に対応） */
+export const SPEAKER_COLORS = [
+  '#3B82F6', // 青
+  '#EF4444', // 赤
+  '#10B981', // 緑
+  '#F59E0B', // 黄
+  '#8B5CF6', // 紫
+  '#EC4899', // ピンク
+  '#06B6D4', // シアン
+  '#F97316', // オレンジ
+];
 
 /** フレーズ区切りとなる句読点パターン */
 export const PHRASE_BREAK_CHARS = /[。、！？!?,.\s]/;


### PR DESCRIPTION
## Summary
- `DEFAULT_SPEAKER_NAMES`配列の固定2要素による制限を撤廃
- `generateSpeakerName`関数でインデックスからアルファベット順の話者名を動的に生成
- `num_speakers`のハードコード(2人)を削除し、Scribe APIの話者数自動検出に対応
- 話者表示色を2色から8色に拡張（3人以上の話者を色で区別可能に）
- チャンク結合時の話者IDスワップロジックを3人以上に対応
- APIキーはsettings.json（設定画面）の値を常に優先するよう修正
- Closes #50

## Test plan

### CI自動チェック（PRのChecksタブで確認）
- [x] `backend-test` がパスしていること
- [x] `frontend-test` がパスしていること

### 手動確認
- [x] 3人の話者がいる音声で文字起こしし、Aさん・Bさん・Cさんと表示されること
- [x] 3人の話者がそれぞれ異なる色（青・赤・緑）で表示されること
- [x] npm run dev 再起動後、設定画面で保存したAPIキーで文字起こしが動作すること