### PR TITLE
docs: リリースノートの案内をDMGインストール手順に更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'
-          releaseBody: 'zipファイルをダウンロードして解凍し、アプリケーションフォルダに配置してください。'
+          releaseBody: 'DMGファイルをダウンロードしてダブルクリックし、アプリケーションフォルダにドラッグしてインストールしてください。'
           releaseDraft: false
           prerelease: false
           args: '--target aarch64-apple-darwin'


### PR DESCRIPTION
## 概要

- リリース時のアセット説明文をDMGインストール手順に変更

## Test plan

### CI自動チェック（PRのChecksタブで確認）
- [ ] `backend-test` がパスしていること
- [ ] `frontend-test` がパスしていること

### 手動確認
- [x] `npm run build` でDMGが生成されること
- [x] DMGをダブルクリックしてインストール・起動できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)