### PR TITLE
docs: SECURITY.mdを追加してセキュリティポリシーを定義する

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+| バージョン | サポート状況 |
+|------------|-------------|
+| latest     | ✅          |
+
+## 脆弱性の報告
+
+セキュリティ上の脆弱性を発見した場合は、**公開のIssueには報告しないでください。**
+
+[こちらから非公開で報告してください](https://github.com/saicologic/ai-speak-trace/security/advisories/new)
+
+報告フォームには以下の内容を日本語で記入してください：
+
+| 項目 | 内容 |
+|------|------|
+| Summary | 脆弱性の概要（例：未認証ユーザーが任意コードを実行できる） |
+| Affected products | 影響を受けるバージョン |
+| Severity | 深刻度（Critical / High / Medium / Low） |
+| Description | 脆弱性の詳細・再現手順・影響範囲 |
+| Suggested solution | 可能であれば緩和策・修正案 |
+
+報告を受け次第、調査・対応が完了するまで時間をいただいた上で、公開開示をお願いします。
+
+## 推奨セキュリティプラクティス
+
+- アプリを常に最新バージョンに保つ
+- APIキー（ElevenLabs・Anthropic・AWS）を安全に管理し、外部に漏洩させない


### PR DESCRIPTION
## Summary

- `SECURITY.md` を新規追加し、脆弱性報告ポリシーを定義

## Test plan

- [x] [報告リンク](https://github.com/saicologic/ai-speak-trace/security/advisories/new) が正しく開くこと
- [x] SECURITY.md の内容が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)