### PR TITLE
docs: SECURITY.mdから報告フォームの記入ガイドを削除する

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,16 +12,6 @@
 
 [こちらから非公開で報告してください](https://github.com/saicologic/ai-speak-trace/security/advisories/new)
 
-報告フォームには以下の内容を日本語で記入してください：
-
-| 項目 | 内容 |
-|------|------|
-| Summary | 脆弱性の概要（例：未認証ユーザーが任意コードを実行できる） |
-| Affected products | 影響を受けるバージョン |
-| Severity | 深刻度（Critical / High / Medium / Low） |
-| Description | 脆弱性の詳細・再現手順・影響範囲 |
-| Suggested solution | 可能であれば緩和策・修正案 |
-
 報告を受け次第、調査・対応が完了するまで時間をいただいた上で、公開開示をお願いします。
 
 ## 推奨セキュリティプラクティス


### PR DESCRIPTION
## Summary

- 報告フォームの日本語記入ガイド（テーブル）を削除

## Test plan

- [ ] [報告リンク](https://github.com/saicologic/ai-speak-trace/security/advisories/new) が正しく開くこと
- [ ] SECURITY.md の内容が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)