### PR TITLE
refactor: 音声ファイルの保存先フォルダ名をoutputsからaudioに変更する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ ai-speak-trace/
 ├── frontend/              # フロントエンド（Vite + React）
 └── backend/               # バックエンド API（NestJS）
     └── data/
-        ├── outputs/              # 音声ファイルの配置先
+        ├── audio/                # 音声ファイルの配置先
         ├── transcriptions/       # 文字起こし結果の保存先
         ├── documents/            # PDFファイルの保存先
         └── document-metadata/    # PDFメタデータの保存先

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ open ~/Library/Application\ Support/io.github.saicologic.ai-speak-trace/data
 
 ```
 ~/Library/Application Support/io.github.saicologic.ai-speak-trace/data/
-├── outputs/          # 音声ファイル
+├── audio/            # 音声ファイル
 ├── transcriptions/   # 文字起こし結果
 ├── chunks/           # チャンク分割された音声ファイル（処理中のみ）
 ├── chunked-jobs/     # チャンク分割ジョブの状態

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+| バージョン | サポート状況 |
+|------------|-------------|
+| latest     | ✅          |
+
+## 脆弱性の報告
+
+セキュリティ上の脆弱性を発見した場合は、**公開のIssueには報告しないでください。**
+
+[こちらから非公開で報告してください](https://github.com/saicologic/ai-speak-trace/security/advisories/new)
+
+報告フォームには以下の内容を日本語で記入してください：
+
+| 項目 | 内容 |
+|------|------|
+| Summary | 脆弱性の概要（例：未認証ユーザーが任意コードを実行できる） |
+| Affected products | 影響を受けるバージョン |
+| Severity | 深刻度（Critical / High / Medium / Low） |
+| Description | 脆弱性の詳細・再現手順・影響範囲 |
+| Suggested solution | 可能であれば緩和策・修正案 |
+
+報告を受け次第、調査・対応が完了するまで時間をいただいた上で、公開開示をお願いします。
+
+## 推奨セキュリティプラクティス
+
+- アプリを常に最新バージョンに保つ
+- APIキー（ElevenLabs・Anthropic・AWS）を安全に管理し、外部に漏洩させない

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -46,8 +46,8 @@ lerna-debug.log*
 .tmp
 
 # data directories (keep .gitkeep)
-data/outputs/*
-!data/outputs/.gitkeep
+data/audio/*
+!data/audio/.gitkeep
 data/transcriptions/*
 !data/transcriptions/.gitkeep
 data/documents/*

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,11 +30,11 @@ import { PodcastModule } from './podcast/podcast.module';
           return [];
         }
         const dataDir = configService.get<string>('DATA_DIR') || './data';
-        const outputsDir = resolve(
-          configService.get<string>('OUTPUTS_DIR') ||
-            `${dataDir}/outputs`,
+        const audioDir = resolve(
+          configService.get<string>('AUDIO_DIR') ||
+            `${dataDir}/audio`,
         );
-        return [{ rootPath: outputsDir, serveRoot: '/outputs' }];
+        return [{ rootPath: audioDir, serveRoot: '/audio' }];
       },
       inject: [ConfigService],
     }),

--- a/backend/src/podcast/podcast.controller.ts
+++ b/backend/src/podcast/podcast.controller.ts
@@ -68,7 +68,7 @@ export class PodcastController {
       // 1. Podcastキャッシュからファイルを読み込み
       const buffer = await this.podcastService.readFile(body.fileName);
 
-      // 2. outputs/ ディレクトリにコピー保存
+      // 2. audio/ ディレクトリにコピー保存
       await this.audioStorage.saveFile(body.fileName, buffer);
 
       // 3. 既存の文字起こしフローで処理

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -18,7 +18,7 @@ export interface AppSettings {
   storageType: string;
   paths: {
     dataDir: string;
-    outputsDir: string;
+    audioDir: string;
     transcriptionsDir: string;
     documentsDir: string;
     documentMetadataDir: string;
@@ -54,9 +54,9 @@ export class SettingsService {
       storageType: this.configService.get<string>('STORAGE_TYPE', 'local'),
       paths: {
         dataDir,
-        outputsDir: path.resolve(
-          this.configService.get<string>('OUTPUTS_DIR') ||
-            path.join(dataDir, 'outputs'),
+        audioDir: path.resolve(
+          this.configService.get<string>('AUDIO_DIR') ||
+            path.join(dataDir, 'audio'),
         ),
         transcriptionsDir: path.resolve(
           this.configService.get<string>('TRANSCRIPTIONS_DIR') ||

--- a/backend/src/storage/local/local-audio-storage.ts
+++ b/backend/src/storage/local/local-audio-storage.ts
@@ -22,8 +22,8 @@ export class LocalAudioStorage implements AudioStorage {
   constructor(private readonly configService: ConfigService) {
     const dataDir = this.configService.get<string>('DATA_DIR') || './data';
     this.baseDir = path.resolve(
-      this.configService.get<string>('OUTPUTS_DIR') ||
-        path.join(dataDir, 'outputs'),
+      this.configService.get<string>('AUDIO_DIR') ||
+        path.join(dataDir, 'audio'),
     );
     this.logger.log(`音声ファイルディレクトリ: ${this.baseDir}`);
   }
@@ -60,7 +60,7 @@ export class LocalAudioStorage implements AudioStorage {
   async getPlaybackUrl(fileName: string): Promise<string> {
     // ポートは動的割り当てのためホスト名は返さず、パスのみを返す
     // フロントエンドが BASE_URL と組み合わせて完全なURLを構築する
-    return `/outputs/${encodeURIComponent(fileName)}`;
+    return `/audio/${encodeURIComponent(fileName)}`;
   }
 
   async getUploadUrl(): Promise<string | null> {

--- a/backend/src/storage/s3/s3-audio-storage.ts
+++ b/backend/src/storage/s3/s3-audio-storage.ts
@@ -30,7 +30,7 @@ export class S3AudioStorage implements AudioStorage {
   constructor(private readonly configService: ConfigService) {
     const region = this.configService.get<string>('AWS_REGION', 'ap-northeast-1');
     this.bucket = this.configService.get<string>('S3_BUCKET', '');
-    this.prefix = this.configService.get<string>('S3_AUDIO_PREFIX', 'outputs/');
+    this.prefix = this.configService.get<string>('S3_AUDIO_PREFIX', 'audio/');
 
     if (!this.bucket) {
       throw new Error(

--- a/backend/src/transcription/dto/transcribe-request.dto.ts
+++ b/backend/src/transcription/dto/transcribe-request.dto.ts
@@ -1,5 +1,5 @@
 /** 文字起こしリクエストDTO */
 export class TranscribeRequestDto {
-  /** outputs/ フォルダ内の音声ファイル名 */
+  /** audio/ フォルダ内の音声ファイル名 */
   fileName: string;
 }

--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -165,7 +165,7 @@ ai-speak-trace/
 └── backend/               # バックエンドAPI（NestJS）
     ├── README.md
     └── data/
-        ├── outputs/              # 音声ファイルの配置先
+        ├── audio/                # 音声ファイルの配置先
         ├── transcriptions/       # 文字起こし結果の保存先
         ├── documents/            # PDFファイルの保存先
         └── document-metadata/    # PDFメタデータの保存先

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -168,7 +168,7 @@ export async function fetchAudioFileUrl(fileName: string): Promise<string> {
     throw new Error(`音声ファイルURLの取得に失敗しました: ${res.status}`);
   }
   const data = await res.json();
-  // ローカルモードでは "/outputs/..." 形式のパスが返るため、ベースURLを補完する
+  // ローカルモードでは "/audio/..." 形式のパスが返るため、ベースURLを補完する
   // S3モードでは完全なURLが返るためそのまま使用する
   const url: string = data.url;
   if (url.startsWith('/')) {

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -104,7 +104,7 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
 
   // サブディレクトリ（相対パス表示）
   const subDirs = [
-    { label: '音声ファイル', path: 'outputs/' },
+    { label: '音声ファイル', path: 'audio/' },
     { label: '文字起こし', path: 'transcriptions/' },
     { label: 'PDFドキュメント', path: 'documents/' },
     { label: 'メタデータ', path: 'document-metadata/' },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -140,7 +140,7 @@ export interface AppSettings {
   storageType: string;
   paths: {
     dataDir: string;
-    outputsDir: string;
+    audioDir: string;
     transcriptionsDir: string;
     documentsDir: string;
     documentMetadataDir: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -31,7 +31,7 @@ export default defineConfig(() => {
             target: `http://127.0.0.1:${backendPort}`,
             changeOrigin: true,
           },
-          '/outputs': {
+          '/audio': {
             target: `http://127.0.0.1:${backendPort}`,
             changeOrigin: true,
           },


### PR DESCRIPTION
## Summary

- 音声ファイルの保存先フォルダ名を `outputs/` から `audio/` に変更した
- 環境変数 `OUTPUTS_DIR` → `AUDIO_DIR`、APIパス `/outputs` → `/audio`、型定義 `outputsDir` → `audioDir` を合わせて更新
- `backend/.gitignore` のignoreルールも `data/audio/*` に更新

## Test plan

- [x] CI自動チェック: `backend-test` が通ること
- [x] CI自動チェック: `frontend-test` が通ること
- [x] ローカルモードで音声ファイルをアップロードし、`backend/data/audio/` に保存されること
- [x] アップロードした音声ファイルが再生できること
- [x] 設定画面のデータ保存先に `audio/` と表示されること
- [x] Podcastファイルを文字起こしし、`audio/` にコピーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)