### PR TITLE
feat: 会話分析の実行結果を保存して過去ログを一覧表示できるようにする

### DIFF
--- a/backend/src/interview/analysis-log.storage.ts
+++ b/backend/src/interview/analysis-log.storage.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { existsSync, mkdirSync } from 'fs';
+import { InterviewAnalysis } from './types/interview.types';
+
+/** 会話分析ログをローカルファイルに保存・取得するサービス */
+@Injectable()
+export class AnalysisLogStorage {
+  private readonly logger = new Logger(AnalysisLogStorage.name);
+  private readonly storeDir: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const dataDir = this.configService.get<string>('DATA_DIR') || './data';
+    this.storeDir = path.resolve(path.join(dataDir, 'analysis-logs'));
+
+    if (!existsSync(this.storeDir)) {
+      mkdirSync(this.storeDir, { recursive: true });
+    }
+    this.logger.log(`分析ログ保存ディレクトリ: ${this.storeDir}`);
+  }
+
+  /** ログファイルパスを取得 */
+  private getFilePath(id: string): string {
+    return path.join(this.storeDir, `${id}.json`);
+  }
+
+  /** 分析結果を保存 */
+  async save(analysis: InterviewAnalysis): Promise<void> {
+    const filePath = this.getFilePath(analysis.id);
+    await fs.writeFile(filePath, JSON.stringify(analysis, null, 2), 'utf-8');
+    this.logger.log(`分析ログ保存完了: ${analysis.id}`);
+  }
+
+  /** IDで分析結果を取得 */
+  async findById(id: string): Promise<InterviewAnalysis | null> {
+    const filePath = this.getFilePath(id);
+    if (!existsSync(filePath)) return null;
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content) as InterviewAnalysis;
+  }
+
+  /** 全分析ログをcreatedAt降順で取得（resultsを除いたサマリー） */
+  async findAllSummaries(): Promise<Omit<InterviewAnalysis, 'results'>[]> {
+    if (!existsSync(this.storeDir)) return [];
+
+    const entries = await fs.readdir(this.storeDir, { withFileTypes: true });
+    const summaries: Omit<InterviewAnalysis, 'results'>[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      try {
+        const content = await fs.readFile(
+          path.join(this.storeDir, entry.name),
+          'utf-8',
+        );
+        const log = JSON.parse(content) as InterviewAnalysis;
+        // resultsを除いたサマリーのみ返す
+        const { results: _, ...summary } = log;
+        summaries.push(summary);
+      } catch (error) {
+        this.logger.warn(
+          `分析ログの読み込みに失敗: ${entry.name}`,
+          error,
+        );
+      }
+    }
+
+    // createdAt降順で返す
+    summaries.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+
+    this.logger.log(`分析ログ一覧取得完了: ${summaries.length}件`);
+    return summaries;
+  }
+}

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Get, Param, Body } from '@nestjs/common';
 import { InterviewService } from './interview.service';
 import { GenerateQuestionsDto } from './dto/generate-questions.dto';
 import { AnalyzeDto } from './dto/analyze.dto';
@@ -52,5 +52,19 @@ export class InterviewController {
       dto.utteranceIndices,
     );
     return { analysis };
+  }
+
+  /** 分析ログ一覧: GET /api/interview/logs */
+  @Get('logs')
+  async findAnalysisLogs() {
+    const logs = await this.interviewService.findAnalysisLogs();
+    return { logs };
+  }
+
+  /** 分析ログ詳細: GET /api/interview/logs/:id */
+  @Get('logs/:id')
+  async findAnalysisLogById(@Param('id') id: string) {
+    const log = await this.interviewService.findAnalysisLogById(id);
+    return { log };
   }
 }

--- a/backend/src/interview/interview.module.ts
+++ b/backend/src/interview/interview.module.ts
@@ -3,10 +3,11 @@ import { TranscriptionModule } from '../transcription/transcription.module';
 import { ClaudeModule } from '../claude/claude.module';
 import { InterviewController } from './interview.controller';
 import { InterviewService } from './interview.service';
+import { AnalysisLogStorage } from './analysis-log.storage';
 
 @Module({
   imports: [TranscriptionModule, ClaudeModule],
   controllers: [InterviewController],
-  providers: [InterviewService],
+  providers: [InterviewService, AnalysisLogStorage],
 })
 export class InterviewModule {}

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { ClaudeService } from '../claude/claude.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
+import { AnalysisLogStorage } from './analysis-log.storage';
 import {
   InterviewAnalysis,
   UtteranceContextResult,
@@ -16,6 +17,7 @@ export class InterviewService {
   constructor(
     private readonly claudeService: ClaudeService,
     private readonly store: TranscriptionStoreService,
+    private readonly analysisLogStorage: AnalysisLogStorage,
   ) {}
 
   /** 話者名を取得するヘルパー */
@@ -91,7 +93,7 @@ export class InterviewService {
       speakerName,
     );
 
-    return {
+    const analysis: InterviewAnalysis = {
       id: uuidv4(),
       transcriptionId,
       speakerId,
@@ -100,6 +102,25 @@ export class InterviewService {
       results,
       createdAt: new Date().toISOString(),
     };
+
+    // 分析結果を過去ログとして保存
+    await this.analysisLogStorage.save(analysis);
+
+    return analysis;
+  }
+
+  /** 分析ログ一覧（サマリー）を取得 */
+  async findAnalysisLogs(): Promise<Omit<InterviewAnalysis, 'results'>[]> {
+    return this.analysisLogStorage.findAllSummaries();
+  }
+
+  /** 分析ログ詳細を取得 */
+  async findAnalysisLogById(id: string): Promise<InterviewAnalysis> {
+    const log = await this.analysisLogStorage.findById(id);
+    if (!log) {
+      throw new NotFoundException(`分析ログが見つかりません: ${id}`);
+    }
+    return log;
   }
 
   /** 発言の文脈を分析 */

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -6,6 +6,7 @@ import type {
   DeepSearchResponse,
   DocumentInfo,
   InterviewAnalysis,
+  InterviewAnalysisSummary,
   Transcription,
   TranscriptionSummary,
 } from '../types';
@@ -516,6 +517,26 @@ export async function analyzeInterview(
   }
   const data = await res.json();
   return data.analysis;
+}
+
+/** 分析ログ一覧（サマリー）を取得 */
+export async function fetchAnalysisLogs(): Promise<InterviewAnalysisSummary[]> {
+  const res = await fetch(`${BASE_URL}/interview/logs`);
+  if (!res.ok) {
+    throw new Error(`分析ログ一覧の取得に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.logs;
+}
+
+/** 分析ログ詳細を取得 */
+export async function fetchAnalysisLog(id: string): Promise<InterviewAnalysis> {
+  const res = await fetch(`${BASE_URL}/interview/logs/${encodeURIComponent(id)}`);
+  if (!res.ok) {
+    throw new Error(`分析ログの取得に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.log;
 }
 
 /** プロンプトプレビューを取得 */

--- a/frontend/src/components/InterviewPage.css
+++ b/frontend/src/components/InterviewPage.css
@@ -380,3 +380,193 @@
   line-height: 1.6;
   color: #374151;
 }
+
+/* タブ切り替え */
+.interview-tabs {
+  display: flex;
+  gap: 0;
+  background-color: #f3f4f6;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.interview-tab {
+  padding: 0.65rem 1.5rem;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background-color: transparent;
+  color: #6b7280;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.interview-tab:hover {
+  color: #374151;
+  background-color: #e5e7eb;
+}
+
+.interview-tab.active {
+  color: #1d4ed8;
+  border-bottom-color: #3b82f6;
+  background-color: #ffffff;
+}
+
+/* 過去ログタブのレイアウト */
+.interview-logs-layout {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  height: calc(100vh - 100px);
+}
+
+/* ログ一覧 */
+.interview-logs-list {
+  width: 260px;
+  flex-shrink: 0;
+  border-right: 1px solid #e5e7eb;
+  background-color: #f9fafb;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.interview-logs-list-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #6b7280;
+  background-color: #f3f4f6;
+  border-bottom: 1px solid #e5e7eb;
+  flex-shrink: 0;
+}
+
+.interview-logs-refresh {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #9ca3af;
+  font-size: 1rem;
+  padding: 0.15rem 0.3rem;
+  border-radius: 4px;
+  transition: color 0.15s;
+}
+
+.interview-logs-refresh:hover:not(:disabled) {
+  color: #374151;
+  background-color: #e5e7eb;
+}
+
+.interview-logs-refresh:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.interview-logs-empty {
+  padding: 2rem 1rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.interview-log-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  border: none;
+  border-bottom: 1px solid #e5e7eb;
+  background-color: transparent;
+  cursor: pointer;
+  transition: background-color 0.1s;
+}
+
+.interview-log-item:hover {
+  background-color: #e5e7eb;
+}
+
+.interview-log-item.selected {
+  background-color: #eff6ff;
+  border-left: 3px solid #3b82f6;
+}
+
+.interview-log-item-speaker {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 0.2rem;
+}
+
+.interview-log-item-keywords {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-bottom: 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.interview-log-item-date {
+  font-size: 0.7rem;
+  color: #9ca3af;
+}
+
+/* ログ詳細 */
+.interview-logs-detail {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem 2rem;
+  background-color: #f9fafb;
+}
+
+.interview-logs-detail-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 0.9rem;
+  color: #9ca3af;
+}
+
+.interview-logs-detail-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.interview-logs-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.interview-logs-detail-speaker {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.interview-logs-detail-date {
+  font-size: 0.8rem;
+  color: #9ca3af;
+}
+
+.interview-logs-detail-keywords {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.interview-logs-keyword-tag {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  background-color: #fef9c3;
+  border: 1px solid #facc15;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  color: #92400e;
+}

--- a/frontend/src/components/InterviewPage.tsx
+++ b/frontend/src/components/InterviewPage.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { marked } from 'marked';
-import { generateQuestions, analyzeInterview } from '../api/client';
+import { generateQuestions, analyzeInterview, fetchAnalysisLogs, fetchAnalysisLog } from '../api/client';
 import { extractKeywords } from '../utils/keywords';
-import type { InterviewAnalysis, Speaker, Utterance } from '../types';
+import type { InterviewAnalysis, InterviewAnalysisSummary, Speaker, Utterance } from '../types';
 import './InterviewPage.css';
 
 // markedの設定: リンクを新しいタブで開く
@@ -44,6 +44,49 @@ export function InterviewPage({
   const [generatingQuestions, setGeneratingQuestions] = useState(false);
   const [analyzing, setAnalyzing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // 過去ログ関連の状態
+  const [logs, setLogs] = useState<InterviewAnalysisSummary[]>([]);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
+  const [logDetail, setLogDetail] = useState<InterviewAnalysis | null>(null);
+  const [logDetailLoading, setLogDetailLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<'new' | 'logs'>('new');
+
+  /** 過去ログを取得 */
+  const loadLogs = async () => {
+    setLogsLoading(true);
+    try {
+      const result = await fetchAnalysisLogs();
+      setLogs(result);
+    } catch {
+      // ログ取得失敗は無視（初回は空）
+    } finally {
+      setLogsLoading(false);
+    }
+  };
+
+  // タブ切り替え時にログを読み込む
+  useEffect(() => {
+    if (activeTab === 'logs') {
+      loadLogs();
+    }
+  }, [activeTab]);
+
+  /** ログ詳細を表示 */
+  const handleSelectLog = async (id: string) => {
+    setSelectedLogId(id);
+    setLogDetail(null);
+    setLogDetailLoading(true);
+    try {
+      const detail = await fetchAnalysisLog(id);
+      setLogDetail(detail);
+    } catch {
+      setLogDetail(null);
+    } finally {
+      setLogDetailLoading(false);
+    }
+  };
 
   /** 選択中の話者の発話テキストからキーワードを抽出（メモ化） */
   const keywords = useMemo(() => {
@@ -139,6 +182,8 @@ export function InterviewPage({
         checkedQuestions,
       );
       setAnalysis(result);
+      // 分析完了後にログ一覧を更新（新規タブに戻った場合用）
+      loadLogs();
     } catch (e) {
       setError(e instanceof Error ? e.message : '分析に失敗しました');
     } finally {
@@ -157,6 +202,27 @@ export function InterviewPage({
     }));
   }, [analysis]);
 
+  /** ログ詳細のMarkdownをHTMLに変換（メモ化） */
+  const renderedLogResults = useMemo(() => {
+    if (!logDetail) return [];
+    return logDetail.results.map((result) => ({
+      ...result,
+      answerHtml: marked.parse(result.answer) as string,
+    }));
+  }, [logDetail]);
+
+  /** 日時を表示用にフォーマット */
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
   return (
     <div className="interview-page">
       <header className="interview-header">
@@ -166,149 +232,259 @@ export function InterviewPage({
         <h1>会話分析</h1>
       </header>
 
-      <div className="interview-content">
-        {error && <div className="interview-error">{error}</div>}
+      {/* タブ切り替え */}
+      <div className="interview-tabs">
+        <button
+          className={`interview-tab ${activeTab === 'new' ? 'active' : ''}`}
+          onClick={() => setActiveTab('new')}
+        >
+          新規分析
+        </button>
+        <button
+          className={`interview-tab ${activeTab === 'logs' ? 'active' : ''}`}
+          onClick={() => setActiveTab('logs')}
+        >
+          過去の分析ログ
+        </button>
+      </div>
 
-        {/* 話者選択 */}
-        <section className="interview-section">
-          <h2>話者を選択</h2>
-          <select
-            className="interview-select"
-            value={selectedSpeakerId}
-            onChange={(e) => handleSpeakerChange(e.target.value)}
-          >
-            {speakers.map((speaker) => (
-              <option key={speaker.id} value={speaker.id}>
-                {speaker.name}
-              </option>
-            ))}
-          </select>
-        </section>
+      {/* 新規分析タブ */}
+      {activeTab === 'new' && (
+        <div className="interview-content">
+          {error && <div className="interview-error">{error}</div>}
 
-        {/* キーワード選択 */}
-        <section className="interview-section">
-          <h2>分析キーワード</h2>
-          <p className="interview-hint">
-            クリックでキーワードを選択（{selectedKeywords.size}件選択中）
-          </p>
-          <div className="interview-keywords">
-            {keywords.map((kw) => (
-              <button
-                key={kw.text}
-                className={`interview-keyword-tag ${selectedKeywords.has(kw.text) ? 'selected' : ''}`}
-                onClick={() => toggleKeyword(kw.text)}
-              >
-                {kw.text}
-              </button>
-            ))}
-          </div>
-        </section>
-
-        {/* 質問生成・選択 */}
-        <section className="interview-section">
-          <h2>調査質問</h2>
-          <div className="interview-actions">
-            <button
-              className="interview-button secondary"
-              onClick={handleGenerateQuestions}
-              disabled={generatingQuestions || analyzing || activeKeywords.length === 0}
-            >
-              {generatingQuestions ? '生成中...' : '質問を生成'}
-            </button>
-          </div>
-
-          {questions.length > 0 && (
-            <div className="question-list">
-              <div className="question-list-header">
-                <button
-                  className="question-toggle-all"
-                  onClick={toggleAllQuestions}
-                >
-                  {questions.every((q) => q.checked) ? '全解除' : '全選択'}
-                </button>
-                <span className="question-list-count">
-                  {checkedCount}/{questions.length}件 選択中
-                </span>
-              </div>
-              {questions.map((q, i) => (
-                <label key={i} className="question-checkbox-item">
-                  <input
-                    type="checkbox"
-                    checked={q.checked}
-                    onChange={() => toggleQuestion(i)}
-                    disabled={analyzing}
-                  />
-                  <span className="question-checkbox-text">{q.text}</span>
-                </label>
-              ))}
-            </div>
-          )}
-
-          {questions.length > 0 && (
-            <div className="interview-actions">
-              <button
-                className="interview-button primary"
-                onClick={handleAnalyze}
-                disabled={analyzing || generatingQuestions || checkedCount === 0}
-              >
-                {analyzing ? '分析中...' : `分析する（${checkedCount}件）`}
-              </button>
-            </div>
-          )}
-        </section>
-
-        {/* ローディング */}
-        {analyzing && (
-          <div className="interview-loading">
-            <div className="loading-spinner" />
-            <p>Claude がWeb検索しながら分析中...</p>
-            <p className="interview-loading-hint">
-              質問数に応じて数十秒〜数分かかる場合があります
-            </p>
-          </div>
-        )}
-
-        {/* 分析結果 */}
-        {analysis && !analyzing && (
+          {/* 話者選択 */}
           <section className="interview-section">
-            <h2>
-              分析結果 —{' '}
-              <span style={{ color: selectedSpeaker?.color }}>
-                {analysis.speakerName}
-              </span>
-            </h2>
-            <div className="interview-results">
-              {renderedResults.map((result, i) => (
-                <div key={i} className="interview-result-card">
-                  <h3 className="result-question">
-                    Q{i + 1}: {result.question}
-                  </h3>
-                  <div
-                    className="result-answer"
-                    dangerouslySetInnerHTML={{ __html: result.answerHtml }}
-                  />
-                  {result.sources.length > 0 && (
-                    <div className="result-sources">
-                      <span className="result-sources-label">出典:</span>
-                      {result.sources.map((source, j) => (
-                        <a
-                          key={j}
-                          href={source.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="result-source-link"
-                        >
-                          {source.title}
-                        </a>
-                      ))}
-                    </div>
-                  )}
-                </div>
+            <h2>話者を選択</h2>
+            <select
+              className="interview-select"
+              value={selectedSpeakerId}
+              onChange={(e) => handleSpeakerChange(e.target.value)}
+            >
+              {speakers.map((speaker) => (
+                <option key={speaker.id} value={speaker.id}>
+                  {speaker.name}
+                </option>
+              ))}
+            </select>
+          </section>
+
+          {/* キーワード選択 */}
+          <section className="interview-section">
+            <h2>分析キーワード</h2>
+            <p className="interview-hint">
+              クリックでキーワードを選択（{selectedKeywords.size}件選択中）
+            </p>
+            <div className="interview-keywords">
+              {keywords.map((kw) => (
+                <button
+                  key={kw.text}
+                  className={`interview-keyword-tag ${selectedKeywords.has(kw.text) ? 'selected' : ''}`}
+                  onClick={() => toggleKeyword(kw.text)}
+                >
+                  {kw.text}
+                </button>
               ))}
             </div>
           </section>
-        )}
-      </div>
+
+          {/* 質問生成・選択 */}
+          <section className="interview-section">
+            <h2>調査質問</h2>
+            <div className="interview-actions">
+              <button
+                className="interview-button secondary"
+                onClick={handleGenerateQuestions}
+                disabled={generatingQuestions || analyzing || activeKeywords.length === 0}
+              >
+                {generatingQuestions ? '生成中...' : '質問を生成'}
+              </button>
+            </div>
+
+            {questions.length > 0 && (
+              <div className="question-list">
+                <div className="question-list-header">
+                  <button
+                    className="question-toggle-all"
+                    onClick={toggleAllQuestions}
+                  >
+                    {questions.every((q) => q.checked) ? '全解除' : '全選択'}
+                  </button>
+                  <span className="question-list-count">
+                    {checkedCount}/{questions.length}件 選択中
+                  </span>
+                </div>
+                {questions.map((q, i) => (
+                  <label key={i} className="question-checkbox-item">
+                    <input
+                      type="checkbox"
+                      checked={q.checked}
+                      onChange={() => toggleQuestion(i)}
+                      disabled={analyzing}
+                    />
+                    <span className="question-checkbox-text">{q.text}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+
+            {questions.length > 0 && (
+              <div className="interview-actions">
+                <button
+                  className="interview-button primary"
+                  onClick={handleAnalyze}
+                  disabled={analyzing || generatingQuestions || checkedCount === 0}
+                >
+                  {analyzing ? '分析中...' : `分析する（${checkedCount}件）`}
+                </button>
+              </div>
+            )}
+          </section>
+
+          {/* ローディング */}
+          {analyzing && (
+            <div className="interview-loading">
+              <div className="loading-spinner" />
+              <p>Claude がWeb検索しながら分析中...</p>
+              <p className="interview-loading-hint">
+                質問数に応じて数十秒〜数分かかる場合があります
+              </p>
+            </div>
+          )}
+
+          {/* 分析結果 */}
+          {analysis && !analyzing && (
+            <section className="interview-section">
+              <h2>
+                分析結果 —{' '}
+                <span style={{ color: selectedSpeaker?.color }}>
+                  {analysis.speakerName}
+                </span>
+              </h2>
+              <AnalysisResultList results={renderedResults} />
+            </section>
+          )}
+        </div>
+      )}
+
+      {/* 過去ログタブ */}
+      {activeTab === 'logs' && (
+        <div className="interview-logs-layout">
+          {/* ログ一覧 */}
+          <div className="interview-logs-list">
+            <div className="interview-logs-list-header">
+              <span>分析履歴</span>
+              <button
+                className="interview-logs-refresh"
+                onClick={loadLogs}
+                disabled={logsLoading}
+                title="更新"
+              >
+                ↻
+              </button>
+            </div>
+            {logsLoading ? (
+              <div className="interview-logs-empty">読み込み中...</div>
+            ) : logs.length === 0 ? (
+              <div className="interview-logs-empty">
+                過去の分析結果がありません
+              </div>
+            ) : (
+              logs.map((log) => (
+                <button
+                  key={log.id}
+                  className={`interview-log-item ${selectedLogId === log.id ? 'selected' : ''}`}
+                  onClick={() => handleSelectLog(log.id)}
+                >
+                  <div className="interview-log-item-speaker">
+                    {log.speakerName}
+                  </div>
+                  <div className="interview-log-item-keywords">
+                    {log.keywords.slice(0, 3).join('・')}
+                    {log.keywords.length > 3 && ` 他${log.keywords.length - 3}件`}
+                  </div>
+                  <div className="interview-log-item-date">
+                    {formatDate(log.createdAt)}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+
+          {/* ログ詳細 */}
+          <div className="interview-logs-detail">
+            {!selectedLogId && (
+              <div className="interview-logs-detail-empty">
+                左の一覧から分析結果を選択してください
+              </div>
+            )}
+            {selectedLogId && logDetailLoading && (
+              <div className="interview-logs-detail-empty">読み込み中...</div>
+            )}
+            {selectedLogId && !logDetailLoading && logDetail && (
+              <>
+                <div className="interview-logs-detail-header">
+                  <div className="interview-logs-detail-meta">
+                    <span className="interview-logs-detail-speaker">
+                      {logDetail.speakerName}
+                    </span>
+                    <span className="interview-logs-detail-date">
+                      {formatDate(logDetail.createdAt)}
+                    </span>
+                  </div>
+                  <div className="interview-logs-detail-keywords">
+                    {logDetail.keywords.map((kw) => (
+                      <span key={kw} className="interview-logs-keyword-tag">
+                        {kw}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+                <AnalysisResultList results={renderedLogResults} />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 分析結果カードリスト（新規・過去ログ共通） */
+function AnalysisResultList({
+  results,
+}: {
+  results: { question: string; answerHtml: string; sources: { title: string; url: string }[] }[];
+}) {
+  return (
+    <div className="interview-results">
+      {results.map((result, i) => (
+        <div key={i} className="interview-result-card">
+          <h3 className="result-question">
+            Q{i + 1}: {result.question}
+          </h3>
+          <div
+            className="result-answer"
+            dangerouslySetInnerHTML={{ __html: result.answerHtml }}
+          />
+          {result.sources.length > 0 && (
+            <div className="result-sources">
+              <span className="result-sources-label">出典:</span>
+              {result.sources.map((source, j) => (
+                <a
+                  key={j}
+                  href={source.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="result-source-link"
+                >
+                  {source.title}
+                </a>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/components/InterviewPage.tsx
+++ b/frontend/src/components/InterviewPage.tsx
@@ -53,12 +53,18 @@ export function InterviewPage({
   const [logDetailLoading, setLogDetailLoading] = useState(false);
   const [activeTab, setActiveTab] = useState<'new' | 'logs'>('new');
 
-  /** 過去ログを取得 */
+  /** 過去ログを取得（現在の文字起こしに絞り込み、最新順） */
   const loadLogs = async () => {
     setLogsLoading(true);
     try {
       const result = await fetchAnalysisLogs();
-      setLogs(result);
+      const filtered = result
+        .filter((l) => l.transcriptionId === transcriptionId)
+        .sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+      setLogs(filtered);
     } catch {
       // ログ取得失敗は無視（初回は空）
     } finally {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -134,6 +134,9 @@ export interface DeepSearchAnalysis {
   analyzedAt: string;
 }
 
+/** 会話分析ログサマリー（results を除いた一覧表示用） */
+export type InterviewAnalysisSummary = Omit<InterviewAnalysis, 'results'>;
+
 /** アプリ設定 */
 export interface AppSettings {
   appVersion: string;


### PR DESCRIPTION
## Summary
- 会話分析の実行結果を `data/analysis-logs/` にJSONファイルとして自動保存する
- `GET /api/interview/logs` で一覧、`GET /api/interview/logs/:id` で詳細を取得できるAPIを追加
- 会話分析ページにタブ（新規分析 / 過去の分析ログ）を追加し、過去の分析結果を一覧から選択して詳細閲覧できるようにする
- Closes #58

## Test plan

### CI自動チェック（PRのChecksタブで確認）
- [x] `backend-test` がパスしていること
- [x] `frontend-test` がパスしていること

### 手動確認
- [x] 会話分析を実行すると `data/analysis-logs/` にJSONファイルが保存されること
- [x] 「過去の分析ログ」タブを開くと過去の分析結果一覧が表示されること（話者名・キーワード・日時）
- [x] 一覧から項目を選択すると分析結果の詳細（質問・回答・出典）が表示されること
- [x] ログが0件の場合「過去の分析結果がありません」と表示されること
- [x] 新規分析タブでの分析実行後、過去ログタブに切り替えると新しいログが表示されること