### PR TITLE
fix: Dependabotアラート対応フローの整備とAPIテストカバレッジの拡充

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/v0.5.7"
+    labels:
+      - "dependencies"
+      - "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/v0.5.7"
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    target-branch: "release/v0.5.7"
+    labels:
+      - "dependencies"
+      - "rust"

--- a/backend/package.json
+++ b/backend/package.json
@@ -89,6 +89,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(uuid)/)"
+    ],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/backend/src/document/document.service.spec.ts
+++ b/backend/src/document/document.service.spec.ts
@@ -1,0 +1,144 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { DocumentService } from './document.service';
+import { EmbeddingService } from './embedding.service';
+import { VectorSearchService } from './vector-search.service';
+import { DOCUMENT_STORAGE } from '../storage/interfaces/document-storage.interface';
+import { DocumentMetadata } from './types/document.types';
+
+/** テスト用のDocumentMetadataを生成するヘルパー */
+function makeMetadata(overrides?: Partial<DocumentMetadata>): DocumentMetadata {
+  return {
+    id: 'doc-001',
+    fileName: 'test.pdf',
+    sizeBytes: 1024,
+    status: 'processing',
+    chunkCount: 0,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const mockStorage = {
+  saveFile: jest.fn(),
+  readFile: jest.fn(),
+  deleteFile: jest.fn(),
+  saveMetadata: jest.fn(),
+  findMetadataById: jest.fn(),
+  findAllMetadata: jest.fn(),
+  deleteMetadata: jest.fn(),
+};
+
+const mockEmbeddingService = {
+  generateEmbeddings: jest.fn(),
+};
+
+const mockVectorSearchService = {
+  putVectors: jest.fn(),
+  deleteByDocumentId: jest.fn(),
+};
+
+describe('DocumentService', () => {
+  let service: DocumentService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentService,
+        { provide: DOCUMENT_STORAGE, useValue: mockStorage },
+        { provide: EmbeddingService, useValue: mockEmbeddingService },
+        { provide: VectorSearchService, useValue: mockVectorSearchService },
+      ],
+    }).compile();
+
+    service = module.get<DocumentService>(DocumentService);
+    jest.clearAllMocks();
+  });
+
+  describe('upload', () => {
+    it('ファイルを保存してmetadataを返す', async () => {
+      mockStorage.saveFile.mockResolvedValueOnce(undefined);
+      mockStorage.saveMetadata.mockResolvedValueOnce(undefined);
+      // processDocumentは非同期で実行されるためモックしておく
+      mockStorage.findMetadataById.mockResolvedValue(null);
+
+      const result = await service.upload('test.pdf', Buffer.from('pdf'), 1024);
+
+      expect(result.fileName).toBe('test.pdf');
+      expect(result.sizeBytes).toBe(1024);
+      expect(result.status).toBe('processing');
+      expect(result.id).toBeTruthy();
+      expect(mockStorage.saveFile).toHaveBeenCalledTimes(1);
+      expect(mockStorage.saveMetadata).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('listDocuments', () => {
+    it('全ドキュメントの一覧を返す', async () => {
+      const docs = [makeMetadata(), makeMetadata({ id: 'doc-002', fileName: 'other.pdf' })];
+      mockStorage.findAllMetadata.mockResolvedValueOnce(docs);
+
+      const result = await service.listDocuments();
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('doc-001');
+    });
+  });
+
+  describe('getStatus', () => {
+    it('存在するドキュメントのステータスを返す', async () => {
+      const metadata = makeMetadata({ status: 'searchable' });
+      mockStorage.findMetadataById.mockResolvedValueOnce(metadata);
+
+      const result = await service.getStatus('doc-001');
+
+      expect(result.status).toBe('searchable');
+    });
+
+    it('存在しないIDはNotFoundExceptionをスローする', async () => {
+      mockStorage.findMetadataById.mockResolvedValueOnce(null);
+
+      await expect(service.getStatus('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('ドキュメントとベクトルと関連メタデータを削除する', async () => {
+      const metadata = makeMetadata();
+      mockStorage.findMetadataById.mockResolvedValueOnce(metadata);
+      mockVectorSearchService.deleteByDocumentId.mockResolvedValueOnce(undefined);
+      mockStorage.deleteFile.mockResolvedValueOnce(undefined);
+      mockStorage.deleteMetadata.mockResolvedValueOnce(undefined);
+
+      await service.deleteDocument('doc-001');
+
+      expect(mockVectorSearchService.deleteByDocumentId).toHaveBeenCalledWith('doc-001');
+      expect(mockStorage.deleteFile).toHaveBeenCalledWith('doc-001');
+      expect(mockStorage.deleteMetadata).toHaveBeenCalledWith('doc-001');
+    });
+
+    it('存在しないIDはNotFoundExceptionをスローする', async () => {
+      mockStorage.findMetadataById.mockResolvedValueOnce(null);
+
+      await expect(service.deleteDocument('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('ベクトル削除が失敗してもファイル削除は続行する', async () => {
+      const metadata = makeMetadata();
+      mockStorage.findMetadataById.mockResolvedValueOnce(metadata);
+      mockVectorSearchService.deleteByDocumentId.mockRejectedValueOnce(
+        new Error('ベクトルDB接続エラー'),
+      );
+      mockStorage.deleteFile.mockResolvedValueOnce(undefined);
+      mockStorage.deleteMetadata.mockResolvedValueOnce(undefined);
+
+      await expect(service.deleteDocument('doc-001')).resolves.not.toThrow();
+      expect(mockStorage.deleteFile).toHaveBeenCalledWith('doc-001');
+      expect(mockStorage.deleteMetadata).toHaveBeenCalledWith('doc-001');
+    });
+  });
+});

--- a/backend/src/settings/settings.service.spec.ts
+++ b/backend/src/settings/settings.service.spec.ts
@@ -1,0 +1,172 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let tmpDir: string;
+  let settingsFilePath: string;
+
+  /** 一時ディレクトリに設定ファイルを書き込むヘルパー */
+  function writeSettings(content: object) {
+    fs.writeFileSync(settingsFilePath, JSON.stringify(content), 'utf-8');
+  }
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'settings-test-'));
+    settingsFilePath = path.join(tmpDir, 'settings.json');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SettingsService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string, defaultValue?: string) => {
+              const map: Record<string, string> = {
+                SETTINGS_FILE: settingsFilePath,
+                DATA_DIR: path.join(tmpDir, 'data'),
+                STORAGE_TYPE: 'local',
+              };
+              return map[key] ?? defaultValue ?? '';
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SettingsService>(SettingsService);
+    process.env.ELEVENLABS_API_KEY = '';
+    process.env.ANTHROPIC_API_KEY = '';
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    delete process.env.ELEVENLABS_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  describe('getSettings', () => {
+    it('初期状態で正しいデフォルト値を返す', () => {
+      const settings = service.getSettings();
+
+      expect(settings.storageType).toBe('local');
+      expect(settings.enableDeepSearch).toBe(false);
+      expect(settings.enableContextAnalysis).toBe(false);
+      expect(settings.paths.dataDir).toBeTruthy();
+      expect(settings.paths.audioDir).toContain('audio');
+      expect(settings.paths.transcriptionsDir).toContain('transcriptions');
+    });
+
+    it('settings.jsonが存在する場合はその値を反映する', () => {
+      writeSettings({ enableDeepSearch: true, enableContextAnalysis: true });
+
+      const settings = service.getSettings();
+
+      expect(settings.enableDeepSearch).toBe(true);
+      expect(settings.enableContextAnalysis).toBe(true);
+    });
+
+    it('settings.jsonが壊れていてもクラッシュせずデフォルト値を返す', () => {
+      fs.writeFileSync(settingsFilePath, 'invalid json', 'utf-8');
+
+      const settings = service.getSettings();
+
+      expect(settings.enableDeepSearch).toBe(false);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('elevenlabsApiKeyを更新するとprocess.envに即時反映される', () => {
+      const result = service.updateSettings({ elevenlabsApiKey: 'new-key-123' });
+
+      expect(result.restartRequired).toBe(false);
+      expect(process.env.ELEVENLABS_API_KEY).toBe('new-key-123');
+    });
+
+    it('anthropicApiKeyを更新するとprocess.envに即時反映される', () => {
+      service.updateSettings({ anthropicApiKey: 'anthropic-key-456' });
+
+      expect(process.env.ANTHROPIC_API_KEY).toBe('anthropic-key-456');
+    });
+
+    it('enableDeepSearchをtrueに更新できる', () => {
+      const result = service.updateSettings({ enableDeepSearch: true });
+
+      expect(result.settings.enableDeepSearch).toBe(true);
+    });
+
+    it('enableContextAnalysisをtrueに更新できる', () => {
+      const result = service.updateSettings({ enableContextAnalysis: true });
+
+      expect(result.settings.enableContextAnalysis).toBe(true);
+    });
+
+    it('更新内容がsettings.jsonに永続化される', () => {
+      service.updateSettings({ enableDeepSearch: true, elevenlabsApiKey: 'saved-key' });
+
+      const raw = JSON.parse(fs.readFileSync(settingsFilePath, 'utf-8')) as {
+        enableDeepSearch: boolean;
+        elevenlabsApiKey: string;
+      };
+      expect(raw.enableDeepSearch).toBe(true);
+      expect(raw.elevenlabsApiKey).toBe('saved-key');
+    });
+
+    it('既存の設定値を上書きせずに部分更新できる', () => {
+      writeSettings({ enableDeepSearch: true, enableContextAnalysis: false });
+
+      service.updateSettings({ enableContextAnalysis: true });
+
+      const raw = JSON.parse(fs.readFileSync(settingsFilePath, 'utf-8')) as {
+        enableDeepSearch: boolean;
+        enableContextAnalysis: boolean;
+      };
+      expect(raw.enableDeepSearch).toBe(true);
+      expect(raw.enableContextAnalysis).toBe(true);
+    });
+  });
+
+  describe('loadSettingsIntoEnv（静的メソッド）', () => {
+    it('settings.jsonのAPIキーをprocess.envに読み込む', () => {
+      const tempSettings = path.join(tmpDir, 'static-settings.json');
+      fs.writeFileSync(
+        tempSettings,
+        JSON.stringify({
+          elevenlabsApiKey: 'static-el-key',
+          anthropicApiKey: 'static-ant-key',
+        }),
+        'utf-8',
+      );
+      process.env.SETTINGS_FILE = tempSettings;
+
+      SettingsService.loadSettingsIntoEnv();
+
+      expect(process.env.ELEVENLABS_API_KEY).toBe('static-el-key');
+      expect(process.env.ANTHROPIC_API_KEY).toBe('static-ant-key');
+
+      delete process.env.SETTINGS_FILE;
+    });
+
+    it('settings.jsonが存在しない場合はクラッシュしない', () => {
+      process.env.SETTINGS_FILE = path.join(tmpDir, 'nonexistent.json');
+
+      expect(() => SettingsService.loadSettingsIntoEnv()).not.toThrow();
+
+      delete process.env.SETTINGS_FILE;
+    });
+
+    it('settings.jsonが壊れていてもクラッシュしない', () => {
+      const tempSettings = path.join(tmpDir, 'broken-settings.json');
+      fs.writeFileSync(tempSettings, 'not-json', 'utf-8');
+      process.env.SETTINGS_FILE = tempSettings;
+
+      expect(() => SettingsService.loadSettingsIntoEnv()).not.toThrow();
+
+      delete process.env.SETTINGS_FILE;
+    });
+  });
+});

--- a/backend/src/transcription/elevenlabs.service.spec.ts
+++ b/backend/src/transcription/elevenlabs.service.spec.ts
@@ -1,0 +1,234 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import axios from 'axios';
+import { ElevenLabsService } from './elevenlabs.service';
+import { ElevenLabsResponse } from './types/elevenlabs.types';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+/** テスト用の最小限のElevenLabsレスポンスを生成 */
+function makeElResponse(overrides?: Partial<ElevenLabsResponse>): ElevenLabsResponse {
+  return {
+    language_code: 'ja',
+    language_probability: 0.99,
+    text: 'こんにちは',
+    transcription_id: 'test-id-001',
+    words: [
+      {
+        text: 'こんにちは',
+        start: 0,
+        end: 1.0,
+        type: 'word',
+        speaker_id: 'speaker_0',
+        logprob: -0.1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('ElevenLabsService', () => {
+  let service: ElevenLabsService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ElevenLabsService],
+    }).compile();
+
+    service = module.get<ElevenLabsService>(ElevenLabsService);
+    process.env.ELEVENLABS_API_KEY = 'test-api-key';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    delete process.env.ELEVENLABS_API_KEY;
+  });
+
+  describe('transcribe', () => {
+    it('正常なAPIレスポンスをパースして返す', async () => {
+      const response = makeElResponse();
+      mockedAxios.post.mockResolvedValueOnce({ status: 200, data: response });
+
+      const result = await service.transcribe(Buffer.from('audio'), 'test.mp3');
+
+      expect(result.language_code).toBe('ja');
+      expect(result.words).toHaveLength(1);
+      expect(result.transcription_id).toBe('test-id-001');
+    });
+
+    it('APIキーが未設定の場合はエラーをスローする', async () => {
+      delete process.env.ELEVENLABS_API_KEY;
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toThrow('ELEVENLABS_API_KEY が設定されていません');
+    });
+
+    it('APIキーが"your_api_key_here"の場合はエラーをスローする', async () => {
+      process.env.ELEVENLABS_API_KEY = 'your_api_key_here';
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toThrow('ELEVENLABS_API_KEY が設定されていません');
+    });
+
+    it('401レスポンスでAPIキー無効エラーをスローする', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 401,
+        data: { detail: 'Unauthorized' },
+      });
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toThrow('ElevenLabs APIキーが無効です');
+    });
+
+    it('429レスポンスでレート制限エラーをスローする', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 429,
+        data: { detail: 'Rate limit exceeded' },
+      });
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toThrow('レート制限');
+    });
+
+    it('クォータ超過（401 + quota_exceeded）でQuotaExceededErrorをスローする', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        status: 401,
+        data: {
+          detail: {
+            status: 'quota_exceeded',
+            message:
+              'Your quota of 100000 characters has been reached. You have 0 credits remaining. 5000 credits are required.',
+          },
+        },
+      });
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toMatchObject({ name: 'QuotaExceededError' });
+    });
+
+    it('タイムアウト（ECONNABORTED）でTranscriptionTimeoutErrorをスローする', async () => {
+      const timeoutError = new Error('timeout');
+      (timeoutError as NodeJS.ErrnoException).code = 'ECONNABORTED';
+      mockedAxios.isAxiosError = jest.fn().mockReturnValue(true);
+      mockedAxios.post.mockRejectedValueOnce(timeoutError);
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toMatchObject({ name: 'TranscriptionTimeoutError' });
+    });
+
+    it('ネットワークエラーで接続失敗エラーをスローする', async () => {
+      mockedAxios.isAxiosError = jest.fn().mockReturnValue(false);
+      mockedAxios.post.mockRejectedValueOnce(new Error('Network Error'));
+
+      await expect(
+        service.transcribe(Buffer.from('audio'), 'test.mp3'),
+      ).rejects.toThrow('ElevenLabs APIへの接続に失敗しました');
+    });
+  });
+
+  describe('checkCredits', () => {
+    it('正常なサブスクリプション情報を返す', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          character_count: 1000,
+          character_limit: 10000,
+          next_character_count_reset_unix: 1700000000,
+        },
+      });
+
+      const result = await service.checkCredits();
+
+      expect(result.characterCount).toBe(1000);
+      expect(result.characterLimit).toBe(10000);
+      expect(result.remainingCredits).toBe(9000);
+      expect(result.nextResetDate).toBeTruthy();
+    });
+
+    it('APIキーが未設定の場合はエラーをスローする', async () => {
+      delete process.env.ELEVENLABS_API_KEY;
+
+      await expect(service.checkCredits()).rejects.toThrow(
+        'ELEVENLABS_API_KEY が設定されていません',
+      );
+    });
+
+    it('401レスポンスでAPIキー無効エラーをスローする', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ status: 401, data: {} });
+
+      await expect(service.checkCredits()).rejects.toThrow(
+        'ElevenLabs APIキーが無効です',
+      );
+    });
+
+    it('レスポンスの値がundefinedの場合は0をデフォルト値として使用する', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 200,
+        data: {},
+      });
+
+      const result = await service.checkCredits();
+
+      expect(result.characterCount).toBe(0);
+      expect(result.characterLimit).toBe(0);
+      expect(result.remainingCredits).toBe(0);
+      expect(result.nextResetDate).toBe('');
+    });
+  });
+
+  describe('getTranscriptionStatus', () => {
+    it('200レスポンスでcompletedを返す', async () => {
+      const data = makeElResponse();
+      mockedAxios.get.mockResolvedValueOnce({ status: 200, data });
+
+      const result = await service.getTranscriptionStatus('test-id-001');
+
+      expect(result.status).toBe('completed');
+      expect(result.data).toEqual(data);
+    });
+
+    it('404レスポンスでerrorを返す', async () => {
+      mockedAxios.get.mockResolvedValueOnce({ status: 404, data: {} });
+
+      const result = await service.getTranscriptionStatus('unknown-id');
+
+      expect(result.status).toBe('error');
+      expect(result.error_message).toContain('見つかりません');
+    });
+
+    it('401レスポンスでerrorを返す', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        status: 401,
+        data: 'Unauthorized',
+      });
+
+      const result = await service.getTranscriptionStatus('test-id-001');
+
+      expect(result.status).toBe('error');
+      expect(result.error_message).toContain('認証エラー');
+    });
+
+    it('APIキーが未設定の場合はエラーをスローする', async () => {
+      delete process.env.ELEVENLABS_API_KEY;
+
+      await expect(
+        service.getTranscriptionStatus('test-id-001'),
+      ).rejects.toThrow('ELEVENLABS_API_KEY が設定されていません');
+    });
+
+    it('ネットワークエラー時はerrorを返す', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('connection refused'));
+
+      const result = await service.getTranscriptionStatus('test-id-001');
+
+      expect(result.status).toBe('error');
+      expect(result.error_message).toBe('connection refused');
+    });
+  });
+});

--- a/backend/src/transcription/transcription.controller.spec.ts
+++ b/backend/src/transcription/transcription.controller.spec.ts
@@ -1,0 +1,271 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { TranscriptionController } from './transcription.controller';
+import { TranscriptionService } from './transcription.service';
+import { ElevenLabsService } from './elevenlabs.service';
+
+/** TranscriptionServiceのモック */
+const mockTranscriptionService = {
+  getAudioFiles: jest.fn(),
+  checkAudioFileExists: jest.fn(),
+  deleteAllResourcesByFileName: jest.fn(),
+  getUploadUrl: jest.fn(),
+  uploadAudioFile: jest.fn(),
+  getAudioFileUrl: jest.fn(),
+  transcribe: jest.fn(),
+  findActiveJob: jest.fn(),
+  getResumableJobs: jest.fn(),
+  isJobProcessing: jest.fn(),
+  getJobDetail: jest.fn(),
+  deleteJob: jest.fn(),
+  resumeTranscription: jest.fn(),
+  getTranscriptions: jest.fn(),
+  getTranscription: jest.fn(),
+  updateSpeakers: jest.fn(),
+  getChunksBaseDir: jest.fn(),
+};
+
+/** ElevenLabsServiceのモック */
+const mockElevenLabsService = {
+  checkCredits: jest.fn(),
+};
+
+describe('TranscriptionController', () => {
+  let controller: TranscriptionController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TranscriptionController],
+      providers: [
+        { provide: TranscriptionService, useValue: mockTranscriptionService },
+        { provide: ElevenLabsService, useValue: mockElevenLabsService },
+      ],
+    }).compile();
+
+    controller = module.get<TranscriptionController>(TranscriptionController);
+    jest.clearAllMocks();
+  });
+
+  describe('checkCredits', () => {
+    it('クレジット情報を返す', async () => {
+      const creditInfo = {
+        characterCount: 500,
+        characterLimit: 10000,
+        remainingCredits: 9500,
+        nextResetDate: '2026-07-01T00:00:00.000Z',
+      };
+      mockElevenLabsService.checkCredits.mockResolvedValueOnce(creditInfo);
+
+      const result = await controller.checkCredits();
+
+      expect(result).toEqual({ creditInfo });
+    });
+
+    it('APIキー未設定時は422エラーを返す', async () => {
+      mockElevenLabsService.checkCredits.mockRejectedValue(
+        new Error('ELEVENLABS_API_KEY が設定されていません'),
+      );
+
+      await expect(controller.checkCredits()).rejects.toMatchObject({
+        status: HttpStatus.UNPROCESSABLE_ENTITY,
+      });
+    });
+
+    it('その他のエラーは502を返す', async () => {
+      mockElevenLabsService.checkCredits.mockRejectedValueOnce(
+        new Error('connection error'),
+      );
+
+      await expect(controller.checkCredits()).rejects.toMatchObject({
+        status: HttpStatus.BAD_GATEWAY,
+      });
+    });
+  });
+
+  describe('getAudioFiles', () => {
+    it('音声ファイル一覧を返す', async () => {
+      const files = [
+        { fileName: 'test.mp3', sizeBytes: 1000, lastModified: '2026-01-01' },
+      ];
+      mockTranscriptionService.getAudioFiles.mockResolvedValueOnce(files);
+
+      const result = await controller.getAudioFiles();
+
+      expect(result).toEqual({ files });
+    });
+  });
+
+  describe('checkAudioFileExists', () => {
+    it('ファイルが存在する場合はtrueを返す', async () => {
+      mockTranscriptionService.checkAudioFileExists.mockResolvedValueOnce(true);
+
+      const result = await controller.checkAudioFileExists('test.mp3');
+
+      expect(result).toEqual({ exists: true });
+    });
+
+    it('ファイルが存在しない場合はfalseを返す', async () => {
+      mockTranscriptionService.checkAudioFileExists.mockResolvedValueOnce(false);
+
+      const result = await controller.checkAudioFileExists('missing.mp3');
+
+      expect(result).toEqual({ exists: false });
+    });
+  });
+
+  describe('uploadAudioFile', () => {
+    it('日本語ファイル名をUTF-8で正しく保存する', async () => {
+      // Multerはlatin1でデコードするため、latin1でエンコードされた日本語ファイル名をシミュレート
+      const originalName = Buffer.from('テスト音声.mp3').toString('latin1');
+      const file = {
+        originalname: originalName,
+        buffer: Buffer.from('audio data'),
+        size: 10,
+      } as Express.Multer.File;
+      mockTranscriptionService.uploadAudioFile.mockResolvedValueOnce(undefined);
+
+      const result = await controller.uploadAudioFile(file);
+
+      expect(result.fileName).toBe('テスト音声.mp3');
+      expect(mockTranscriptionService.uploadAudioFile).toHaveBeenCalledWith(
+        'テスト音声.mp3',
+        file.buffer,
+      );
+    });
+
+    it('ファイルが指定されていない場合は400エラーを返す', async () => {
+      await expect(
+        controller.uploadAudioFile(undefined as unknown as Express.Multer.File),
+      ).rejects.toThrow(HttpException);
+    });
+  });
+
+  describe('transcribe', () => {
+    it('文字起こし結果を返す', async () => {
+      const transcription = { id: 'tr-001', text: 'こんにちは' };
+      mockTranscriptionService.transcribe.mockResolvedValueOnce(transcription);
+
+      const result = await controller.transcribe({ fileName: 'test.mp3' });
+
+      expect(result).toEqual({ transcription });
+    });
+
+    it('QuotaExceededErrorは402を返す', async () => {
+      const error = new Error('利用枠の上限に達しました');
+      error.name = 'QuotaExceededError';
+      mockTranscriptionService.transcribe.mockRejectedValueOnce(error);
+
+      await expect(
+        controller.transcribe({ fileName: 'test.mp3' }),
+      ).rejects.toMatchObject({ status: HttpStatus.PAYMENT_REQUIRED });
+    });
+
+    it('TranscriptionTimeoutErrorは408を返す', async () => {
+      const error = new Error('タイムアウト');
+      error.name = 'TranscriptionTimeoutError';
+      mockTranscriptionService.transcribe.mockRejectedValueOnce(error);
+
+      await expect(
+        controller.transcribe({ fileName: 'test.mp3' }),
+      ).rejects.toMatchObject({ status: HttpStatus.REQUEST_TIMEOUT });
+    });
+
+    it('APIキー未設定エラーは422を返す', async () => {
+      mockTranscriptionService.transcribe.mockRejectedValueOnce(
+        new Error('ELEVENLABS_API_KEY が設定されていません'),
+      );
+
+      await expect(
+        controller.transcribe({ fileName: 'test.mp3' }),
+      ).rejects.toMatchObject({ status: HttpStatus.UNPROCESSABLE_ENTITY });
+    });
+
+    it('ffmpeg未インストールエラーは422を返す', async () => {
+      mockTranscriptionService.transcribe.mockRejectedValueOnce(
+        new Error('ffprobeが見つかりません'),
+      );
+
+      await expect(
+        controller.transcribe({ fileName: 'test.mp3' }),
+      ).rejects.toMatchObject({ status: HttpStatus.UNPROCESSABLE_ENTITY });
+    });
+
+    it('その他のエラーは500を返す', async () => {
+      mockTranscriptionService.transcribe.mockRejectedValueOnce(
+        new Error('unexpected error'),
+      );
+
+      await expect(
+        controller.transcribe({ fileName: 'test.mp3' }),
+      ).rejects.toMatchObject({ status: HttpStatus.INTERNAL_SERVER_ERROR });
+    });
+  });
+
+  describe('getTranscriptions', () => {
+    it('文字起こし一覧を返す', async () => {
+      const transcriptions = [{ id: 'tr-001' }, { id: 'tr-002' }];
+      mockTranscriptionService.getTranscriptions.mockResolvedValueOnce(transcriptions);
+
+      const result = await controller.getTranscriptions();
+
+      expect(result).toEqual({ transcriptions });
+    });
+  });
+
+  describe('getTranscription', () => {
+    it('指定したIDの文字起こし結果を返す', async () => {
+      const transcription = { id: 'tr-001', text: 'テスト' };
+      mockTranscriptionService.getTranscription.mockResolvedValueOnce(transcription);
+
+      const result = await controller.getTranscription('tr-001');
+
+      expect(result).toEqual({ transcription });
+    });
+  });
+
+  describe('getResumableJobs', () => {
+    it('ジョブ一覧にisProcessingを付与して返す', async () => {
+      const jobs = [{ id: 'job-001' }, { id: 'job-002' }];
+      mockTranscriptionService.getResumableJobs.mockResolvedValueOnce(jobs);
+      mockTranscriptionService.isJobProcessing.mockReturnValueOnce(true).mockReturnValueOnce(false);
+
+      const result = await controller.getResumableJobs();
+
+      expect(result.jobs).toHaveLength(2);
+      expect(result.jobs[0].isProcessing).toBe(true);
+      expect(result.jobs[1].isProcessing).toBe(false);
+    });
+  });
+
+  describe('deleteJob', () => {
+    it('存在するジョブを削除できる', async () => {
+      mockTranscriptionService.getJobDetail.mockResolvedValueOnce({ id: 'job-001' });
+      mockTranscriptionService.deleteJob.mockResolvedValueOnce(undefined);
+
+      const result = await controller.deleteJob('job-001');
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it('存在しないジョブは404を返す', async () => {
+      mockTranscriptionService.getJobDetail.mockResolvedValueOnce(null);
+
+      await expect(controller.deleteJob('nonexistent')).rejects.toThrow(
+        'ジョブが見つかりません',
+      );
+    });
+  });
+
+  describe('updateSpeakers', () => {
+    it('話者名を更新して返す', async () => {
+      const updated = { id: 'tr-001', speakers: [{ id: 'speaker_0', name: 'Aさん', color: '#3B82F6' }] };
+      mockTranscriptionService.updateSpeakers.mockResolvedValueOnce(updated);
+
+      const result = await controller.updateSpeakers('tr-001', {
+        speakers: [{ id: 'speaker_0', name: 'Aさん', color: '#3B82F6' }],
+      });
+
+      expect(result).toEqual({ transcription: updated });
+    });
+  });
+});


### PR DESCRIPTION
## 変更内容

- `.github/dependabot.yml` を新規追加し、DependabotのPRターゲットブランチを `main` から `release/v0.5.7` に変更
- `ElevenLabsService`・`SettingsService`・`TranscriptionController`・`DocumentService` のユニットテストを追加（56テストケース追加、合計117件）
- `uuid` v14のESMモジュール問題に対応するため、JestのtransformIgnorePatternsを設定

## 変更理由

Dependabotが直接 `main` へのPRを作成していたため、レビューなしにマージされるリスクがあった。また、ライブラリアップデート後にAPIの動作を検証するためのテストが不足していた。

## カバレッジ向上（追加前→追加後）

| ファイル | 追加前 | 追加後 |
|---|---|---|
| `elevenlabs.service.ts` | 0% | 93% |
| `transcription.controller.ts` | 0% | 60% |
| `settings.service.ts` | 0% | 94% |
| `document.service.ts` | 0% | 59% |

## テスト

- [x] `backend-test`（CI自動チェック）
- [x] `frontend-test`（CI自動チェック）
- [ ] `npm run build`（ローカルでビルド成功を確認）

## 破壊的変更

なし

---
⚠️ **運用メモ**: 次回 `v0.5.8` リリース時は `.github/dependabot.yml` の `target-branch` を `release/v0.5.8` に更新してください。