### PR TITLE
fix: 依存パッケージ差分チェックをすべてのmainへのPRで実行するよう変更

### DIFF
--- a/.github/workflows/dependabot-diff.yml
+++ b/.github/workflows/dependabot-diff.yml
@@ -1,14 +1,12 @@
-name: Dependabot 差分チェック
+name: 依存パッケージ差分チェック
 
 on:
   pull_request:
     branches: [main]
 
-# Dependabotのpull_requestトリガーは読み取り専用のため、
 # 差分情報をアーティファクトに保存し、workflow_runで拾ってコメント投稿する
 jobs:
   diff:
-    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- `dependabot-diff.yml` の `if: github.actor == 'dependabot[bot]'` 条件を削除
- mainへのPRであれば、Dependabot以外（fix/*, release/* 経由）でも差分チェックが実行されるようになる
- ワークフロー名も「Dependabot 差分チェック」→「依存パッケージ差分チェック」に変更

## Test plan

- [x] `backend-test`: CI自動チェックでテストが通ること
- [x] `frontend-test`: CI自動チェックでテストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)