### PR TITLE
fix: PRテストプランにnpm run buildの条件判断を追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,3 +104,12 @@ PRのTest planにはCI自動チェック（`backend-test`, `frontend-test`）と
 - release/* → `/release`
 - fix/*, feature/* → `/fix-issue`
 - 脆弱性対応 → `/audit`
+
+### 手動確認項目の条件判断
+
+`npm run build`（backendディレクトリで実行）は、以下の場合のみTest planに含める:
+
+- `backend/` 配下のコードを変更した場合
+- `backend/package.json` または `backend/package-lock.json` を変更した場合
+
+`frontend/`・`.github/workflows/`・`CLAUDE.md`・`src-tauri/` のみの変更では含めない。


### PR DESCRIPTION
## Summary

- `npm run build`（backendディレクトリ）の手動確認は、backendに変更がある場合のみ実施する条件をCLAUDE.mdに追記
- `frontend/`・`.github/workflows/`・`CLAUDE.md`・`src-tauri/` のみの変更では不要であることを明示

## Test plan

- [x] `backend-test`: CI自動チェックでテストが通ること
- [x] `frontend-test`: CI自動チェックでテストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)