### PR TITLE
fix: リリースワークフローをタグ専用に分離しビルドチェックを別ファイルに切り出す

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - 'release/*'
+
+jobs:
+  build:
+    runs-on: macos-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - run: npm ci
+
+      - run: cd backend && npm ci
+
+      - run: cd frontend && npm ci
+
+      # sidecarバイナリをtauri-action実行前に生成
+      - name: バックエンドsidecarバイナリ生成
+        run: npm run pkg:backend
+
+      # 署名なしでビルドのみ実行
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: '--target aarch64-apple-darwin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,15 @@ jobs:
       - name: バックエンドsidecarバイナリ生成
         run: npm run pkg:backend
 
-      # 署名なしでビルドのみ実行
+      # リリース作成なし・署名ありでビルドのみ実行
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         with:
           args: '--target aarch64-apple-darwin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -34,20 +32,6 @@ jobs:
       - run: cd backend && npm ci
 
       - run: cd frontend && npm ci
-
-      # タグまたはブランチ名からバージョンを取得してtauri.conf.jsonに同期
-      - name: バージョンを同期
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION=${GITHUB_REF_NAME#v}
-          elif [[ "$GITHUB_REF" == refs/heads/release/v* ]]; then
-            VERSION=${GITHUB_REF_NAME#release/v}
-          else
-            echo "タグ・リリースブランチ以外のため、バージョン同期をスキップします"
-            exit 0
-          fi
-          echo "同期するバージョン: $VERSION"
-          sed -i '' "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
 
       # sidecarバイナリをtauri-action実行前に生成
       - name: バックエンドsidecarバイナリ生成


### PR DESCRIPTION
## 問題

`release.yml` に `pull_request` トリガーが設定されていたことで以下の問題が発生していた。

1. dependabotのPRでSecretsにアクセスできず、コード署名エラーが発生する
2. `release/*` へのPR作成時に `tauri-action` がタグを誤作成する

## 変更内容

**`release.yml`**
- `pull_request` トリガーを削除し、タグプッシュ時（`v*`）のみ実行するよう変更
- 署名・公証・リリース作成はタグプッシュ時のみ実行される

**`build.yml`（新規）**
- `release/*` へのPR時に署名なしでビルドエラーのみチェックする専用ワークフローを追加

## Test plan

- [x] CI `backend-test` が通ること
- [x] CI `frontend-test` が通ること
- [x] CI `build` でビルドが成功すること