### PR TITLE
fix: release.ymlのリリースノートをPRの変更内容から自動生成する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,41 @@ jobs:
       - name: バックエンドsidecarバイナリ生成
         run: npm run pkg:backend
 
+      # release/vX.Y.Z PRの「変更内容」セクションをリリースノートに使用
+      - name: リリースノート生成
+        id: release_notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+
+          # release/vX.Y.Z にマージされたPRを検索
+          PR_BODY=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --state merged \
+            --search "release: v${VERSION} in:title" \
+            --json body \
+            --jq '.[0].body // ""')
+
+          # "## 変更内容" セクションを抽出し "## " で始まる次のセクションの直前まで取得
+          CHANGES=$(echo "$PR_BODY" | awk '/^## 変更内容/{found=1; next} found && /^## /{exit} found{print}')
+
+          if [ -z "$CHANGES" ]; then
+            echo "::error::release: v${VERSION} のPRが見つからないか、「## 変更内容」セクションがありません"
+            exit 1
+          fi
+
+          BODY="## 変更内容
+          ${CHANGES}
+
+          ## インストール方法
+          DMGファイルをダウンロードしてマウントし、アプリケーションフォルダにドラッグしてください。"
+
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
       - uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -52,7 +87,7 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: 'v__VERSION__'
-          releaseBody: 'DMGファイルをダウンロードしてマウントし、アプリケーションフォルダにドラッグしてください。'
+          releaseBody: ${{ steps.release_notes.outputs.body }}
           releaseDraft: false
           prerelease: false
           args: '--target aarch64-apple-darwin'

--- a/scripts/preview-release-notes.sh
+++ b/scripts/preview-release-notes.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# リリースノートのプレビュー確認用スクリプト
+# 使い方: ./scripts/preview-release-notes.sh v0.5.9
+
+set -e
+
+TAG="${1:-}"
+if [ -z "$TAG" ]; then
+  echo "使い方: $0 <タグ名>"
+  echo "例: $0 v0.5.9"
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+REPO="saicologic/ai-speak-trace"
+
+echo "=== リリースノートプレビュー: ${TAG} ==="
+echo ""
+
+PR_BODY=$(gh pr list \
+  --repo "$REPO" \
+  --state merged \
+  --search "release: v${VERSION} in:title" \
+  --json body \
+  --jq '.[0].body // ""')
+
+CHANGES=$(echo "$PR_BODY" | awk '/^## 変更内容/{found=1; next} found && /^## /{exit} found{print}')
+
+if [ -z "$CHANGES" ]; then
+  echo "エラー: release: v${VERSION} のPRが見つからないか、「## 変更内容」セクションがありません" >&2
+  exit 1
+fi
+
+cat <<EOF
+## 変更内容
+${CHANGES}
+
+## インストール方法
+DMGファイルをダウンロードしてマウントし、アプリケーションフォルダにドラッグしてください。
+EOF


### PR DESCRIPTION
## 変更内容

- `release.yml` のリリースノートを固定文字列からPRの「## 変更内容」セクションを自動抽出する方式に変更
- 対応するPRが見つからない・「## 変更内容」セクションがない場合はCIエラーにする
- リリースノートのプレビュー確認用スクリプト `scripts/preview-release-notes.sh` を追加

## Test plan

- [x] CI `backend-test` が通ること
- [x] CI `frontend-test` が通ること