### PR TITLE
fix: ソースコード変更時のみビルドCIを実行するようpathsフィルターを追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'release/*'
       - main
+    paths:
+      - 'src-tauri/**'
+      - 'frontend/**'
+      - 'backend/**'
 
 jobs:
   build:


### PR DESCRIPTION
## 変更内容

- `build.yml` に `paths` フィルターを追加し、`src-tauri/`・`frontend/`・`backend/` 配下の変更があるときのみビルドCIを実行するよう変更
- `.github/workflows/` や `CLAUDE.md` のみの変更ではビルドをスキップする

## Test plan

- [x] CI `backend-test` が通ること
- [x] CI `frontend-test` が通ること