### PR TITLE
test: バックエンド・フロントエンドのテストカバレッジを大幅に拡充する

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -103,6 +103,9 @@
       "**/*.(t|j)s"
     ],
     "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "silent": true,
+    "verbose": true,
+    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"]
   }
 }

--- a/backend/src/deep-search/deep-search.service.spec.ts
+++ b/backend/src/deep-search/deep-search.service.spec.ts
@@ -1,0 +1,252 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeepSearchService } from './deep-search.service';
+import { TranscriptionStoreService } from '../transcription/transcription-store.service';
+import { EmbeddingService } from '../document/embedding.service';
+import { VectorSearchService } from '../document/vector-search.service';
+import { ClaudeService } from '../claude/claude.service';
+import { DeepSearchDto, DeepSearchAnalyzeDto } from './dto/deep-search.dto';
+
+/** テスト用の文字起こしデータ */
+const sampleTranscription = {
+  id: 't1',
+  audioFileName: 'talk.mp3',
+  createdAt: '2024-01-01T00:00:00Z',
+  languageCode: 'ja',
+  fullText: 'AIエコシステムについて話しました',
+  speakers: [{ id: 'speaker_0', name: 'Aさん', color: '#3B82F6' }],
+  words: [],
+  utterances: [
+    {
+      speakerId: 'speaker_0',
+      speakerName: 'Aさん',
+      start: 0,
+      end: 3,
+      text: 'AIエコシステムについて話しました',
+      words: [],
+    },
+    {
+      speakerId: 'speaker_0',
+      speakerName: 'Aさん',
+      start: 3,
+      end: 5,
+      text: '関係のない話',
+      words: [],
+    },
+  ],
+};
+
+describe('DeepSearchService', () => {
+  let service: DeepSearchService;
+  let transcriptionStore: jest.Mocked<TranscriptionStoreService>;
+  let embeddingService: jest.Mocked<EmbeddingService>;
+  let vectorSearchService: jest.Mocked<VectorSearchService>;
+  let claudeService: jest.Mocked<ClaudeService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeepSearchService,
+        {
+          provide: TranscriptionStoreService,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+        {
+          provide: EmbeddingService,
+          useValue: {
+            generateEmbedding: jest.fn(),
+          },
+        },
+        {
+          provide: VectorSearchService,
+          useValue: {
+            search: jest.fn(),
+          },
+        },
+        {
+          provide: ClaudeService,
+          useValue: {
+            searchAndAnalyze: jest.fn(),
+            analyzeSearchResults: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DeepSearchService>(DeepSearchService);
+    transcriptionStore = module.get(TranscriptionStoreService);
+    embeddingService = module.get(EmbeddingService);
+    vectorSearchService = module.get(VectorSearchService);
+    claudeService = module.get(ClaudeService);
+  });
+
+  describe('search', () => {
+    it('キーワードにマッチする会話発話を返す', async () => {
+      transcriptionStore.findById.mockResolvedValue(sampleTranscription);
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: ['t1'],
+        includePdfs: false,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.keywords).toEqual(['AI']);
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].sourceType).toBe('conversation');
+      expect(result.results[0].text).toContain('AI');
+    });
+
+    it('マッチしない発話は含まれない', async () => {
+      transcriptionStore.findById.mockResolvedValue(sampleTranscription);
+
+      const dto: DeepSearchDto = {
+        keywords: ['存在しないキーワード'],
+        transcriptionIds: ['t1'],
+        includePdfs: false,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('transcriptionIdsが空の場合は会話検索をスキップする', async () => {
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: false,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(transcriptionStore.findById).not.toHaveBeenCalled();
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('存在しない文字起こしIDは結果に含めずスキップする', async () => {
+      transcriptionStore.findById.mockResolvedValue(null);
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: ['missing'],
+        includePdfs: false,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('includePdfs=trueのときPDF検索を実行する', async () => {
+      embeddingService.generateEmbedding.mockResolvedValue([0.1, 0.2]);
+      vectorSearchService.search.mockResolvedValue([
+        { text: 'PDF内容', score: 0.9, documentId: 'doc-1', fileName: 'doc.pdf', chunkIndex: 0 },
+      ]);
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: true,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].sourceType).toBe('pdf');
+    });
+
+    it('PDF検索が失敗した場合は空配列でスキップする', async () => {
+      embeddingService.generateEmbedding.mockRejectedValue(new Error('Bedrock error'));
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: true,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('includeWeb=trueのときWeb検索を実行する', async () => {
+      claudeService.searchAndAnalyze.mockResolvedValue({
+        answer: 'Web検索結果テキスト',
+        sources: [{ url: 'https://example.com', title: '例サイト' }],
+      });
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: false,
+        includeWeb: true,
+      };
+
+      const result = await service.search(dto);
+
+      const webResults = result.results.filter((r) => r.sourceType === 'web');
+      expect(webResults.length).toBeGreaterThan(0);
+    });
+
+    it('Web検索が失敗した場合は空配列でスキップする', async () => {
+      claudeService.searchAndAnalyze.mockRejectedValue(new Error('Claude error'));
+
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: false,
+        includeWeb: true,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.results).toHaveLength(0);
+    });
+
+    it('searchedAtを含んで返す', async () => {
+      const dto: DeepSearchDto = {
+        keywords: ['AI'],
+        transcriptionIds: [],
+        includePdfs: false,
+        includeWeb: false,
+      };
+
+      const result = await service.search(dto);
+
+      expect(result.searchedAt).toBeTruthy();
+    });
+  });
+
+  describe('analyzeResults', () => {
+    it('検索結果をClaude APIで分析する', async () => {
+      claudeService.analyzeSearchResults.mockResolvedValue('分析レポート');
+
+      const dto: DeepSearchAnalyzeDto = {
+        keywords: ['AI'],
+        results: [
+          {
+            sourceType: 'conversation',
+            sourceName: 'talk.mp3',
+            sourceId: 't1',
+            text: 'AIエコシステムについて',
+          },
+        ],
+      };
+
+      const result = await service.analyzeResults(dto);
+
+      expect(result.analysis).toBe('分析レポート');
+      expect(result.searchResults).toHaveLength(1);
+      expect(result.analyzedAt).toBeTruthy();
+    });
+  });
+});

--- a/backend/src/interview/analysis-log.storage.spec.ts
+++ b/backend/src/interview/analysis-log.storage.spec.ts
@@ -1,0 +1,104 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { existsSync } from 'fs';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { AnalysisLogStorage } from './analysis-log.storage';
+import { InterviewAnalysis } from './types/interview.types';
+
+/** テスト用の分析ログデータ */
+function makeLog(id: string, createdAt: string): InterviewAnalysis {
+  return {
+    id,
+    transcriptionId: 'sample',
+    speakerId: 'speaker_0',
+    speakerName: 'Aさん',
+    keywords: ['キーワード'],
+    results: [{ question: 'q1', answer: 'a1', sources: [] }],
+    createdAt,
+  };
+}
+
+describe('AnalysisLogStorage', () => {
+  let storage: AnalysisLogStorage;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'analysis-log-test-'));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalysisLogStorage,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'DATA_DIR') return tmpDir;
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    storage = module.get<AnalysisLogStorage>(AnalysisLogStorage);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('save / findById', () => {
+    it('分析ログを保存してIDで取得できる', async () => {
+      const log = makeLog('log-1', '2024-01-01T00:00:00Z');
+
+      await storage.save(log);
+      const found = await storage.findById('log-1');
+
+      expect(found).toEqual(log);
+    });
+
+    it('存在しないIDはnullを返す', async () => {
+      const result = await storage.findById('missing');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAllSummaries', () => {
+    it('createdAt降順でサマリーを返す', async () => {
+      await storage.save(makeLog('log-old', '2024-01-01T00:00:00Z'));
+      await storage.save(makeLog('log-new', '2024-02-01T00:00:00Z'));
+
+      const summaries = await storage.findAllSummaries();
+
+      expect(summaries[0].id).toBe('log-new');
+      expect(summaries[1].id).toBe('log-old');
+    });
+
+    it('サマリーにresultsは含まれない', async () => {
+      await storage.save(makeLog('log-1', '2024-01-01T00:00:00Z'));
+
+      const summaries = await storage.findAllSummaries();
+
+      expect((summaries[0] as any).results).toBeUndefined();
+    });
+
+    it('ログが存在しない場合は空配列を返す', async () => {
+      const summaries = await storage.findAllSummaries();
+      expect(summaries).toEqual([]);
+    });
+
+    it('壊れたJSONファイルは読み込みをスキップする', async () => {
+      const storeDir = path.join(tmpDir, 'analysis-logs');
+      await fs.writeFile(path.join(storeDir, 'broken.json'), 'not-json', 'utf-8');
+      await storage.save(makeLog('log-valid', '2024-01-01T00:00:00Z'));
+
+      const summaries = await storage.findAllSummaries();
+
+      // 壊れたファイルはスキップされ、有効なファイルのみ返る
+      expect(summaries).toHaveLength(1);
+      expect(summaries[0].id).toBe('log-valid');
+    });
+  });
+});

--- a/backend/src/interview/interview.service.spec.ts
+++ b/backend/src/interview/interview.service.spec.ts
@@ -1,0 +1,222 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { InterviewService } from './interview.service';
+import { ClaudeService } from '../claude/claude.service';
+import { TranscriptionStoreService } from '../transcription/transcription-store.service';
+import { AnalysisLogStorage } from './analysis-log.storage';
+
+/** テスト用の文字起こしデータ */
+const sampleTranscription = {
+  id: 'sample',
+  audioFileName: 'sample.mp3',
+  createdAt: '2024-01-01T00:00:00Z',
+  languageCode: 'ja',
+  fullText: 'こんにちは 世界',
+  speakers: [
+    { id: 'speaker_0', name: 'Aさん', color: '#3B82F6' },
+    { id: 'speaker_1', name: 'Bさん', color: '#EF4444' },
+  ],
+  words: [],
+  utterances: [
+    {
+      speakerId: 'speaker_0',
+      speakerName: 'Aさん',
+      start: 0,
+      end: 1,
+      text: 'こんにちは',
+      words: [],
+    },
+    {
+      speakerId: 'speaker_1',
+      speakerName: 'Bさん',
+      start: 1,
+      end: 2,
+      text: '世界',
+      words: [],
+    },
+  ],
+};
+
+describe('InterviewService', () => {
+  let service: InterviewService;
+  let claudeService: jest.Mocked<ClaudeService>;
+  let store: jest.Mocked<TranscriptionStoreService>;
+  let analysisLogStorage: jest.Mocked<AnalysisLogStorage>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        InterviewService,
+        {
+          provide: ClaudeService,
+          useValue: {
+            generateQuestions: jest.fn(),
+            buildGenerateQuestionsPrompt: jest.fn(),
+            buildAnalysisPrompt: jest.fn(),
+            analyze: jest.fn(),
+            analyzeContext: jest.fn(),
+          },
+        },
+        {
+          provide: TranscriptionStoreService,
+          useValue: {
+            findById: jest.fn(),
+          },
+        },
+        {
+          provide: AnalysisLogStorage,
+          useValue: {
+            save: jest.fn(),
+            findById: jest.fn(),
+            findAllSummaries: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<InterviewService>(InterviewService);
+    claudeService = module.get(ClaudeService);
+    store = module.get(TranscriptionStoreService);
+    analysisLogStorage = module.get(AnalysisLogStorage);
+  });
+
+  describe('generateQuestions', () => {
+    it('話者名を取得してClaude APIで調査質問を生成する', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.generateQuestions.mockResolvedValue(['質問1', '質問2']);
+
+      const result = await service.generateQuestions('sample', 'speaker_0', ['キーワード']);
+
+      expect(claudeService.generateQuestions).toHaveBeenCalledWith(['キーワード'], 'Aさん');
+      expect(result).toEqual(['質問1', '質問2']);
+    });
+
+    it('文字起こしが存在しない場合はNotFoundExceptionをスロー', async () => {
+      store.findById.mockResolvedValue(null);
+
+      await expect(
+        service.generateQuestions('missing', 'speaker_0', ['キーワード']),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('話者IDが見つからない場合は話者IDをそのまま使う', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.generateQuestions.mockResolvedValue([]);
+
+      await service.generateQuestions('sample', 'unknown_speaker', []);
+
+      expect(claudeService.generateQuestions).toHaveBeenCalledWith([], 'unknown_speaker');
+    });
+  });
+
+  describe('previewPrompts', () => {
+    it('質問生成プロンプトと分析プロンプトを返す', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.buildGenerateQuestionsPrompt.mockReturnValue('質問生成プロンプト');
+      claudeService.buildAnalysisPrompt.mockReturnValue('分析プロンプト1');
+
+      const result = await service.previewPrompts('sample', 'speaker_0', ['kw'], ['q1']);
+
+      expect(result.generateQuestionsPrompt).toBe('質問生成プロンプト');
+      expect(result.analyzePrompts).toEqual(['分析プロンプト1']);
+    });
+  });
+
+  describe('analyze', () => {
+    it('分析を実行してログに保存する', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.analyze.mockResolvedValue([
+        { question: 'q1', answer: 'a1', sources: [] },
+      ]);
+      analysisLogStorage.save.mockResolvedValue(undefined);
+
+      const result = await service.analyze('sample', 'speaker_0', ['kw'], ['q1']);
+
+      expect(result.transcriptionId).toBe('sample');
+      expect(result.speakerName).toBe('Aさん');
+      expect(result.keywords).toEqual(['kw']);
+      expect(result.results).toHaveLength(1);
+      expect(analysisLogStorage.save).toHaveBeenCalledWith(result);
+    });
+  });
+
+  describe('findAnalysisLogs / findAnalysisLogById', () => {
+    it('分析ログ一覧を取得する', async () => {
+      const summaries = [{ id: 'log-1', transcriptionId: 'sample', speakerId: 'speaker_0', speakerName: 'Aさん', keywords: [], createdAt: '2024-01-01Z' }];
+      analysisLogStorage.findAllSummaries.mockResolvedValue(summaries);
+
+      const result = await service.findAnalysisLogs();
+
+      expect(result).toEqual(summaries);
+    });
+
+    it('IDで分析ログを取得する', async () => {
+      const log = {
+        id: 'log-1',
+        transcriptionId: 'sample',
+        speakerId: 'speaker_0',
+        speakerName: 'Aさん',
+        keywords: [],
+        results: [],
+        createdAt: '2024-01-01Z',
+      };
+      analysisLogStorage.findById.mockResolvedValue(log);
+
+      const result = await service.findAnalysisLogById('log-1');
+
+      expect(result).toEqual(log);
+    });
+
+    it('存在しない分析ログIDはNotFoundExceptionをスロー', async () => {
+      analysisLogStorage.findById.mockResolvedValue(null);
+
+      await expect(service.findAnalysisLogById('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('analyzeContext', () => {
+    it('発話の文脈を分析して結果を返す', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.analyzeContext.mockResolvedValue([
+        { index: 1, intent: '説明', topic: '挨拶' },
+      ]);
+
+      const result = await service.analyzeContext('sample', [1]);
+
+      expect(result.transcriptionId).toBe('sample');
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].utteranceIndex).toBe(1);
+      expect(result.results[0].intent).toBe('説明');
+      expect(result.results[0].topic).toBe('挨拶');
+      // インデックス1の直前発話（インデックス0）が入る
+      expect(result.results[0].previousUtterance?.text).toBe('こんにちは');
+    });
+
+    it('インデックス0の発話はpreviousUtteranceがnull', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.analyzeContext.mockResolvedValue([
+        { index: 0, intent: '質問', topic: '挨拶' },
+      ]);
+
+      const result = await service.analyzeContext('sample', [0]);
+
+      expect(result.results[0].previousUtterance).toBeNull();
+    });
+
+    it('LLMの結果がない発話はデフォルト値を使う', async () => {
+      store.findById.mockResolvedValue(sampleTranscription);
+      claudeService.analyzeContext.mockResolvedValue([]);
+
+      const result = await service.analyzeContext('sample', [0]);
+
+      expect(result.results[0].intent).toBe('その他');
+      expect(result.results[0].topic).toBe('');
+    });
+
+    it('文字起こしが存在しない場合はNotFoundExceptionをスロー', async () => {
+      store.findById.mockResolvedValue(null);
+
+      await expect(service.analyzeContext('missing', [0])).rejects.toThrow(NotFoundException);
+    });
+  });
+});

--- a/backend/src/jest.setup.ts
+++ b/backend/src/jest.setup.ts
@@ -1,0 +1,8 @@
+import { Logger } from '@nestjs/common';
+
+// テスト実行時にNestJSのロガー出力を抑制する（失敗時のJestエラーは通常通り表示される）
+jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+jest.spyOn(Logger.prototype, 'verbose').mockImplementation(() => undefined);

--- a/backend/src/podcast/podcast.service.spec.ts
+++ b/backend/src/podcast/podcast.service.spec.ts
@@ -1,0 +1,97 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { PodcastService } from './podcast.service';
+
+describe('PodcastService', () => {
+  let service: PodcastService;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'podcast-test-'));
+    // PODCAST_CACHE_DIR 環境変数でキャッシュディレクトリを上書き
+    process.env.PODCAST_CACHE_DIR = tmpDir;
+    service = new PodcastService();
+  });
+
+  afterEach(async () => {
+    delete process.env.PODCAST_CACHE_DIR;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('exists / getCacheDir', () => {
+    it('キャッシュディレクトリが存在する場合はtrueを返す', () => {
+      expect(service.exists()).toBe(true);
+    });
+
+    it('getCacheDirはキャッシュディレクトリのパスを返す', () => {
+      expect(service.getCacheDir()).toBe(tmpDir);
+    });
+  });
+
+  describe('listFiles', () => {
+    it('対応する音声ファイルのみを返す', async () => {
+      await fs.writeFile(path.join(tmpDir, 'episode.mp3'), 'data');
+      await fs.writeFile(path.join(tmpDir, 'podcast.m4a'), 'data');
+      await fs.writeFile(path.join(tmpDir, 'image.jpg'), 'data');
+
+      const files = await service.listFiles();
+
+      const fileNames = files.map((f) => f.fileName);
+      expect(fileNames).toContain('episode.mp3');
+      expect(fileNames).toContain('podcast.m4a');
+      expect(fileNames).not.toContain('image.jpg');
+    });
+
+    it('最終更新日時の降順でソートされる', async () => {
+      // mtimeを制御するため writeFile 後に utimes で日時を変更
+      const oldFile = path.join(tmpDir, 'old.mp3');
+      const newFile = path.join(tmpDir, 'new.mp3');
+      await fs.writeFile(oldFile, 'old');
+      await fs.writeFile(newFile, 'new');
+      await fs.utimes(oldFile, new Date('2024-01-01'), new Date('2024-01-01'));
+      await fs.utimes(newFile, new Date('2024-02-01'), new Date('2024-02-01'));
+
+      const files = await service.listFiles();
+
+      expect(files[0].fileName).toBe('new.mp3');
+      expect(files[1].fileName).toBe('old.mp3');
+    });
+
+    it('キャッシュディレクトリが存在しない場合は空配列を返す', async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      process.env.PODCAST_CACHE_DIR = tmpDir;
+      const noService = new PodcastService();
+
+      const files = await noService.listFiles();
+      expect(files).toEqual([]);
+    });
+
+    it('ファイルのサイズと更新日時を含む', async () => {
+      const data = Buffer.from('audio data');
+      await fs.writeFile(path.join(tmpDir, 'ep.mp3'), data);
+
+      const files = await service.listFiles();
+
+      expect(files[0].sizeBytes).toBe(data.length);
+      expect(files[0].lastModified).toBeTruthy();
+    });
+  });
+
+  describe('readFile', () => {
+    it('指定ファイルのBufferを返す', async () => {
+      const data = Buffer.from('podcast audio');
+      await fs.writeFile(path.join(tmpDir, 'ep.mp3'), data);
+
+      const result = await service.readFile('ep.mp3');
+
+      expect(result).toEqual(data);
+    });
+
+    it('存在しないファイルはNotFoundExceptionをスロー', async () => {
+      await expect(service.readFile('missing.mp3')).rejects.toThrow(
+        'Podcastファイルが見つかりません',
+      );
+    });
+  });
+});

--- a/backend/src/settings/settings.controller.spec.ts
+++ b/backend/src/settings/settings.controller.spec.ts
@@ -1,0 +1,69 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SettingsController } from './settings.controller';
+import { SettingsService } from './settings.service';
+
+/** テスト用の設定データ */
+const sampleSettings = {
+  paths: {
+    dataDir: '/tmp/test-data',
+    audioDir: '/tmp/test-data/audio',
+    transcriptionsDir: '/tmp/test-data/transcriptions',
+  },
+  elevenlabsApiKey: 'el-key',
+  anthropicApiKey: 'ant-key',
+  enableDeepSearch: false,
+  enableContextAnalysis: true,
+};
+
+describe('SettingsController', () => {
+  let controller: SettingsController;
+  let settingsService: jest.Mocked<SettingsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SettingsController],
+      providers: [
+        {
+          provide: SettingsService,
+          useValue: {
+            getSettings: jest.fn(),
+            updateSettings: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SettingsController>(SettingsController);
+    settingsService = module.get(SettingsService);
+  });
+
+  describe('getSettings', () => {
+    it('現在の設定をsettingsキーでラップして返す', () => {
+      settingsService.getSettings.mockReturnValue(sampleSettings as any);
+
+      const result = controller.getSettings();
+
+      expect(result).toEqual({ settings: sampleSettings });
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('設定を更新して返す', () => {
+      const updated = { ...sampleSettings, enableDeepSearch: true };
+      settingsService.updateSettings.mockReturnValue(updated as any);
+
+      const result = controller.updateSettings({ enableDeepSearch: true });
+
+      expect(settingsService.updateSettings).toHaveBeenCalledWith({ enableDeepSearch: true });
+      expect(result).toEqual(updated);
+    });
+
+    it('一部のフィールドのみ更新できる', () => {
+      settingsService.updateSettings.mockReturnValue(sampleSettings as any);
+
+      controller.updateSettings({ elevenlabsApiKey: 'new-key' });
+
+      expect(settingsService.updateSettings).toHaveBeenCalledWith({ elevenlabsApiKey: 'new-key' });
+    });
+  });
+});

--- a/backend/src/storage/local/local-audio-storage.spec.ts
+++ b/backend/src/storage/local/local-audio-storage.spec.ts
@@ -1,0 +1,120 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { LocalAudioStorage } from './local-audio-storage';
+
+describe('LocalAudioStorage', () => {
+  let storage: LocalAudioStorage;
+  let tmpDir: string;
+  let audioDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'audio-storage-test-'));
+    audioDir = path.join(tmpDir, 'audio');
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocalAudioStorage,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'DATA_DIR') return tmpDir;
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    storage = module.get<LocalAudioStorage>(LocalAudioStorage);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('saveFile / readFile / exists / deleteFile', () => {
+    it('ファイルを保存して読み込める', async () => {
+      const buffer = Buffer.from('test audio data');
+
+      await storage.saveFile('test.mp3', buffer);
+      const result = await storage.readFile('test.mp3');
+
+      expect(result).toEqual(buffer);
+    });
+
+    it('存在するファイルはtrueを返す', async () => {
+      await storage.saveFile('test.mp3', Buffer.from('data'));
+      expect(await storage.exists('test.mp3')).toBe(true);
+    });
+
+    it('存在しないファイルはfalseを返す', async () => {
+      expect(await storage.exists('missing.mp3')).toBe(false);
+    });
+
+    it('ファイルを削除する', async () => {
+      await storage.saveFile('test.mp3', Buffer.from('data'));
+      await storage.deleteFile('test.mp3');
+
+      expect(await storage.exists('test.mp3')).toBe(false);
+    });
+
+    it('存在しないファイルの削除は何もしない', async () => {
+      await expect(storage.deleteFile('missing.mp3')).resolves.not.toThrow();
+    });
+  });
+
+  describe('listFiles', () => {
+    it('音声ファイルのみを返す', async () => {
+      await storage.saveFile('audio.mp3', Buffer.from('mp3'));
+      await storage.saveFile('audio.wav', Buffer.from('wav'));
+      await storage.saveFile('document.txt', Buffer.from('txt'));
+
+      const files = await storage.listFiles();
+
+      const fileNames = files.map((f) => f.fileName);
+      expect(fileNames).toContain('audio.mp3');
+      expect(fileNames).toContain('audio.wav');
+      expect(fileNames).not.toContain('document.txt');
+    });
+
+    it('ファイルのメタデータ（サイズ・更新日時）を含む', async () => {
+      const buffer = Buffer.from('audio data');
+      await storage.saveFile('test.mp3', buffer);
+
+      const files = await storage.listFiles();
+
+      expect(files[0].sizeBytes).toBe(buffer.length);
+      expect(files[0].lastModified).toBeTruthy();
+    });
+
+    it('ディレクトリが存在しない場合は空配列を返す', async () => {
+      await fs.rm(audioDir, { recursive: true, force: true });
+      const files = await storage.listFiles();
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe('getPlaybackUrl', () => {
+    it('ファイル名をエンコードしたパスを返す', async () => {
+      const url = await storage.getPlaybackUrl('テスト音声.mp3');
+      expect(url).toBe(`/audio/${encodeURIComponent('テスト音声.mp3')}`);
+    });
+  });
+
+  describe('getUploadUrl', () => {
+    it('ローカルストレージはnullを返す', async () => {
+      const url = await storage.getUploadUrl('test.mp3');
+      expect(url).toBeNull();
+    });
+  });
+
+  describe('getBaseDir', () => {
+    it('ベースディレクトリを返す', () => {
+      expect(storage.getBaseDir()).toBe(audioDir);
+    });
+  });
+});

--- a/backend/src/storage/local/local-document-storage.spec.ts
+++ b/backend/src/storage/local/local-document-storage.spec.ts
@@ -1,0 +1,132 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { LocalDocumentStorage } from './local-document-storage';
+import { DocumentMetadata } from '../../document/types/document.types';
+
+/** テスト用のメタデータ */
+function makeMetadata(id: string): DocumentMetadata {
+  return {
+    id,
+    fileName: `${id}.pdf`,
+    sizeBytes: 1024,
+    status: 'searchable',
+    chunkCount: 5,
+    createdAt: '2024-01-01T00:00:00Z',
+  };
+}
+
+describe('LocalDocumentStorage', () => {
+  let storage: LocalDocumentStorage;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'document-storage-test-'));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocalDocumentStorage,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'DATA_DIR') return tmpDir;
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    storage = module.get<LocalDocumentStorage>(LocalDocumentStorage);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('saveFile / readFile / deleteFile', () => {
+    it('ファイルを保存してIDで読み込める', async () => {
+      const buffer = Buffer.from('PDF content');
+
+      await storage.saveFile('doc-1', 'document.pdf', buffer);
+      const result = await storage.readFile('doc-1');
+
+      expect(result).toEqual(buffer);
+    });
+
+    it('存在しないIDのファイル読み込みはエラーをスロー', async () => {
+      await expect(storage.readFile('missing')).rejects.toThrow(
+        'ドキュメントファイルが見つかりません',
+      );
+    });
+
+    it('ファイルを削除する', async () => {
+      await storage.saveFile('doc-1', 'document.pdf', Buffer.from('data'));
+      await storage.deleteFile('doc-1');
+
+      await expect(storage.readFile('doc-1')).rejects.toThrow();
+    });
+
+    it('存在しないファイルの削除は何もしない', async () => {
+      await expect(storage.deleteFile('missing')).resolves.not.toThrow();
+    });
+  });
+
+  describe('saveMetadata / findMetadataById / findAllMetadata / deleteMetadata', () => {
+    it('メタデータを保存してIDで取得できる', async () => {
+      const metadata = makeMetadata('doc-1');
+
+      await storage.saveMetadata(metadata);
+      const found = await storage.findMetadataById('doc-1');
+
+      expect(found).toEqual(metadata);
+    });
+
+    it('存在しないIDのメタデータはnullを返す', async () => {
+      const found = await storage.findMetadataById('missing');
+      expect(found).toBeNull();
+    });
+
+    it('全メタデータを取得できる', async () => {
+      await storage.saveMetadata(makeMetadata('doc-1'));
+      await storage.saveMetadata(makeMetadata('doc-2'));
+
+      const all = await storage.findAllMetadata();
+
+      const ids = all.map((m) => m.id);
+      expect(ids).toContain('doc-1');
+      expect(ids).toContain('doc-2');
+    });
+
+    it('メタデータが存在しない場合は空配列を返す', async () => {
+      const all = await storage.findAllMetadata();
+      expect(all).toEqual([]);
+    });
+
+    it('壊れたJSONファイルはスキップされる', async () => {
+      const metadataDir = path.join(tmpDir, 'document-metadata');
+      await fs.writeFile(path.join(metadataDir, 'broken.json'), 'not-json', 'utf-8');
+      await storage.saveMetadata(makeMetadata('valid-doc'));
+
+      const all = await storage.findAllMetadata();
+
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe('valid-doc');
+    });
+
+    it('メタデータを削除する', async () => {
+      await storage.saveMetadata(makeMetadata('doc-1'));
+      await storage.deleteMetadata('doc-1');
+
+      const found = await storage.findMetadataById('doc-1');
+      expect(found).toBeNull();
+    });
+
+    it('存在しないメタデータの削除は何もしない', async () => {
+      await expect(storage.deleteMetadata('missing')).resolves.not.toThrow();
+    });
+  });
+});

--- a/backend/src/storage/local/local-transcription-storage.spec.ts
+++ b/backend/src/storage/local/local-transcription-storage.spec.ts
@@ -1,0 +1,123 @@
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { LocalTranscriptionStorage } from './local-transcription-storage';
+import { Transcription } from '../../transcription/types/transcription.types';
+
+/** テスト用の文字起こしデータ */
+function makeTranscription(id: string): Transcription {
+  return {
+    id,
+    audioFileName: `${id}.mp3`,
+    createdAt: '2024-01-01T00:00:00Z',
+    languageCode: 'ja',
+    fullText: 'テスト',
+    speakers: [{ id: 'speaker_0', name: 'Aさん', color: '#3B82F6' }],
+    words: [],
+    utterances: [],
+  };
+}
+
+describe('LocalTranscriptionStorage', () => {
+  let storage: LocalTranscriptionStorage;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'transcription-storage-test-'));
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LocalTranscriptionStorage,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'DATA_DIR') return tmpDir;
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    storage = module.get<LocalTranscriptionStorage>(LocalTranscriptionStorage);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('save / findById', () => {
+    it('文字起こしを保存してIDで取得できる', async () => {
+      const transcription = makeTranscription('test-audio');
+
+      await storage.save(transcription);
+      const found = await storage.findById('test-audio');
+
+      expect(found).toEqual(transcription);
+    });
+
+    it('存在しないIDはnullを返す', async () => {
+      const result = await storage.findById('missing');
+      expect(result).toBeNull();
+    });
+
+    it('同じIDで保存すると上書きされる', async () => {
+      const original = makeTranscription('test-audio');
+      await storage.save(original);
+
+      const updated = { ...original, fullText: '更新後のテキスト' };
+      await storage.save(updated);
+
+      const found = await storage.findById('test-audio');
+      expect(found?.fullText).toBe('更新後のテキスト');
+    });
+  });
+
+  describe('findAll', () => {
+    it('保存済みの全文字起こしを返す', async () => {
+      await storage.save(makeTranscription('audio-1'));
+      await storage.save(makeTranscription('audio-2'));
+
+      const all = await storage.findAll();
+
+      const ids = all.map((t) => t.id);
+      expect(ids).toContain('audio-1');
+      expect(ids).toContain('audio-2');
+    });
+
+    it('ストアが空の場合は空配列を返す', async () => {
+      const all = await storage.findAll();
+      expect(all).toEqual([]);
+    });
+
+    it('壊れたJSONファイルはスキップされる', async () => {
+      const storeDir = path.join(tmpDir, 'transcriptions');
+      const brokenDir = path.join(storeDir, 'broken-entry');
+      await fs.mkdir(brokenDir, { recursive: true });
+      await fs.writeFile(path.join(brokenDir, 'transcription.json'), 'not-json', 'utf-8');
+      await storage.save(makeTranscription('valid-audio'));
+
+      const all = await storage.findAll();
+
+      expect(all).toHaveLength(1);
+      expect(all[0].id).toBe('valid-audio');
+    });
+  });
+
+  describe('delete', () => {
+    it('IDで文字起こしを削除する', async () => {
+      await storage.save(makeTranscription('test-audio'));
+      await storage.delete('test-audio');
+
+      const found = await storage.findById('test-audio');
+      expect(found).toBeNull();
+    });
+
+    it('存在しないIDの削除は何もしない', async () => {
+      await expect(storage.delete('missing')).resolves.not.toThrow();
+    });
+  });
+});

--- a/backend/src/transcription/transcription.service.spec.ts
+++ b/backend/src/transcription/transcription.service.spec.ts
@@ -1,0 +1,365 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotFoundException } from '@nestjs/common';
+import { TranscriptionService } from './transcription.service';
+import { ElevenLabsService } from './elevenlabs.service';
+import { ChunkedTranscriptionService } from './chunked-transcription.service';
+import { TranscriptionStoreService } from './transcription-store.service';
+import { AUDIO_STORAGE } from '../storage/interfaces/audio-storage.interface';
+
+/** テスト用の文字起こしデータを生成するヘルパー */
+function makeTranscription(id = 'test-audio', audioFileName = 'test-audio.mp3') {
+  return {
+    id,
+    audioFileName,
+    createdAt: '2024-01-01T00:00:00.000Z',
+    languageCode: 'ja',
+    fullText: 'こんにちは 世界',
+    speakers: [
+      { id: 'speaker_0', name: 'Aさん', color: '#3B82F6' },
+      { id: 'speaker_1', name: 'Bさん', color: '#EF4444' },
+    ],
+    words: [
+      { text: 'こんにちは', start: 0, end: 1, type: 'word' as const, speakerId: 'speaker_0' },
+      { text: '世界', start: 1, end: 2, type: 'word' as const, speakerId: 'speaker_1' },
+    ],
+    utterances: [
+      {
+        speakerId: 'speaker_0',
+        speakerName: 'Aさん',
+        start: 0,
+        end: 1,
+        text: 'こんにちは',
+        words: [{ text: 'こんにちは', start: 0, end: 1, type: 'word' as const, speakerId: 'speaker_0' }],
+      },
+      {
+        speakerId: 'speaker_1',
+        speakerName: 'Bさん',
+        start: 1,
+        end: 2,
+        text: '世界',
+        words: [{ text: '世界', start: 1, end: 2, type: 'word' as const, speakerId: 'speaker_1' }],
+      },
+    ],
+  };
+}
+
+describe('TranscriptionService', () => {
+  let service: TranscriptionService;
+  let elevenLabsService: jest.Mocked<ElevenLabsService>;
+  let chunkedTranscriptionService: jest.Mocked<ChunkedTranscriptionService>;
+  let store: jest.Mocked<TranscriptionStoreService>;
+  let audioStorage: {
+    listFiles: jest.Mock;
+    exists: jest.Mock;
+    readFile: jest.Mock;
+    getPlaybackUrl: jest.Mock;
+    getUploadUrl: jest.Mock;
+    saveFile: jest.Mock;
+    deleteFile: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    audioStorage = {
+      listFiles: jest.fn(),
+      exists: jest.fn(),
+      readFile: jest.fn(),
+      getPlaybackUrl: jest.fn(),
+      getUploadUrl: jest.fn(),
+      saveFile: jest.fn(),
+      deleteFile: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TranscriptionService,
+        {
+          provide: ElevenLabsService,
+          useValue: {
+            transcribe: jest.fn(),
+          },
+        },
+        {
+          provide: ChunkedTranscriptionService,
+          useValue: {
+            createJob: jest.fn(),
+            deleteJob: jest.fn(),
+            findAllJobsByFileName: jest.fn(),
+            findActiveJobByFileName: jest.fn(),
+            getJobStatus: jest.fn(),
+            saveJob: jest.fn(),
+            isJobProcessing: jest.fn(),
+            needsChunking: jest.fn(),
+            startChunkedTranscription: jest.fn(),
+            resumeChunkedTranscription: jest.fn(),
+            getResumableJobs: jest.fn(),
+            getChunksBaseDir: jest.fn(),
+          },
+        },
+        {
+          provide: TranscriptionStoreService,
+          useValue: {
+            save: jest.fn(),
+            findById: jest.fn(),
+            findAll: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+        {
+          provide: AUDIO_STORAGE,
+          useValue: audioStorage,
+        },
+      ],
+    }).compile();
+
+    service = module.get<TranscriptionService>(TranscriptionService);
+    elevenLabsService = module.get(ElevenLabsService);
+    chunkedTranscriptionService = module.get(ChunkedTranscriptionService);
+    store = module.get(TranscriptionStoreService);
+  });
+
+  describe('getAudioFiles', () => {
+    it('最終更新日時の降順で音声ファイル一覧を返す', async () => {
+      audioStorage.listFiles.mockResolvedValue([
+        { fileName: 'old.mp3', sizeBytes: 1000, lastModified: '2024-01-01T00:00:00Z' },
+        { fileName: 'new.mp3', sizeBytes: 2000, lastModified: '2024-02-01T00:00:00Z' },
+      ]);
+
+      const result = await service.getAudioFiles();
+
+      expect(result[0].fileName).toBe('new.mp3');
+      expect(result[1].fileName).toBe('old.mp3');
+    });
+
+    it('ファイルが存在しない場合は空配列を返す', async () => {
+      audioStorage.listFiles.mockResolvedValue([]);
+
+      const result = await service.getAudioFiles();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getAudioFileUrl', () => {
+    it('ファイルが存在する場合は再生URLを返す', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      audioStorage.getPlaybackUrl.mockResolvedValue('/audio/test.mp3');
+
+      const result = await service.getAudioFileUrl('test.mp3');
+
+      expect(result).toBe('/audio/test.mp3');
+    });
+
+    it('ファイルが存在しない場合はNotFoundExceptionをスロー', async () => {
+      audioStorage.exists.mockResolvedValue(false);
+
+      await expect(service.getAudioFileUrl('missing.mp3')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('checkAudioFileExists', () => {
+    it('ファイルが存在する場合はtrueを返す', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      expect(await service.checkAudioFileExists('test.mp3')).toBe(true);
+    });
+
+    it('ファイルが存在しない場合はfalseを返す', async () => {
+      audioStorage.exists.mockResolvedValue(false);
+      expect(await service.checkAudioFileExists('missing.mp3')).toBe(false);
+    });
+  });
+
+  describe('uploadAudioFile', () => {
+    it('音声ファイルを保存する', async () => {
+      audioStorage.saveFile.mockResolvedValue(undefined);
+      const buffer = Buffer.from('test');
+
+      await service.uploadAudioFile('test.mp3', buffer);
+
+      expect(audioStorage.saveFile).toHaveBeenCalledWith('test.mp3', buffer);
+    });
+  });
+
+  describe('deleteAllResourcesByFileName', () => {
+    it('音声ファイル・ジョブ・文字起こし履歴をすべて削除する', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      audioStorage.deleteFile.mockResolvedValue(undefined);
+      chunkedTranscriptionService.findAllJobsByFileName.mockResolvedValue([
+        { id: 'job-1', status: 'completed', audioFileName: 'test.mp3' } as any,
+      ]);
+      chunkedTranscriptionService.deleteJob.mockResolvedValue(undefined);
+      store.findAll.mockResolvedValue([
+        { ...makeTranscription('test-audio', 'test.mp3') },
+        { ...makeTranscription('other-audio', 'other.mp3') },
+      ]);
+      store.delete.mockResolvedValue(undefined);
+
+      await service.deleteAllResourcesByFileName('test.mp3');
+
+      expect(audioStorage.deleteFile).toHaveBeenCalledWith('test.mp3');
+      expect(chunkedTranscriptionService.deleteJob).toHaveBeenCalledWith('job-1');
+      // test.mp3 に紐づく文字起こし（test-audio）だけ削除
+      expect(store.delete).toHaveBeenCalledWith('test-audio');
+      expect(store.delete).not.toHaveBeenCalledWith('other-audio');
+    });
+
+    it('音声ファイルが存在しない場合はファイル削除をスキップする', async () => {
+      audioStorage.exists.mockResolvedValue(false);
+      chunkedTranscriptionService.findAllJobsByFileName.mockResolvedValue([]);
+      store.findAll.mockResolvedValue([]);
+
+      await service.deleteAllResourcesByFileName('missing.mp3');
+
+      expect(audioStorage.deleteFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('transcribe', () => {
+    it('ファイルが存在しない場合はNotFoundExceptionをスロー', async () => {
+      audioStorage.exists.mockResolvedValue(false);
+
+      await expect(service.transcribe('missing.mp3')).rejects.toThrow(NotFoundException);
+    });
+
+    it('10分以下のファイルは一括で文字起こしする', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      audioStorage.readFile.mockResolvedValue(Buffer.from('audio'));
+      chunkedTranscriptionService.createJob.mockResolvedValue({
+        id: 'job-1',
+        status: 'transcribing',
+        audioFileName: 'test.mp3',
+      } as any);
+      chunkedTranscriptionService.isJobProcessing.mockReturnValue(false);
+      chunkedTranscriptionService.needsChunking.mockResolvedValue({ needs: false });
+      chunkedTranscriptionService.deleteJob.mockResolvedValue(undefined);
+      elevenLabsService.transcribe.mockResolvedValue({
+        words: [
+          { text: 'こんにちは', start: 0, end: 1, type: 'word', speaker_id: 'speaker_0', logprob: -0.1 },
+        ],
+        text: 'こんにちは',
+        language_code: 'ja',
+      } as any);
+      store.save.mockResolvedValue(undefined);
+
+      const result = await service.transcribe('test.mp3');
+
+      expect(result.audioFileName).toBe('test.mp3');
+      expect(result.languageCode).toBe('ja');
+      expect(chunkedTranscriptionService.deleteJob).toHaveBeenCalledWith('job-1');
+    });
+
+    it('完了済みジョブで文字起こし結果がある場合は既存の結果を返す', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      audioStorage.readFile.mockResolvedValue(Buffer.from('audio'));
+      chunkedTranscriptionService.createJob.mockResolvedValue({
+        id: 'job-1',
+        status: 'completed',
+        transcriptionId: 'test-audio',
+        audioFileName: 'test.mp3',
+      } as any);
+      const existing = makeTranscription();
+      store.findById.mockResolvedValue(existing);
+
+      const result = await service.transcribe('test.mp3');
+
+      expect(result).toEqual(existing);
+      expect(elevenLabsService.transcribe).not.toHaveBeenCalled();
+    });
+
+    it('処理中のジョブに重複リクエストするとエラーをスロー', async () => {
+      audioStorage.exists.mockResolvedValue(true);
+      audioStorage.readFile.mockResolvedValue(Buffer.from('audio'));
+      chunkedTranscriptionService.createJob.mockResolvedValue({
+        id: 'job-1',
+        status: 'transcribing',
+        audioFileName: 'test.mp3',
+      } as any);
+      chunkedTranscriptionService.isJobProcessing.mockReturnValue(true);
+
+      await expect(service.transcribe('test.mp3')).rejects.toThrow(
+        'このファイルは現在文字起こし処理中です',
+      );
+    });
+  });
+
+  describe('getTranscriptions', () => {
+    it('createdAtの降順で文字起こし一覧を返す', async () => {
+      store.findAll.mockResolvedValue([
+        { ...makeTranscription('old', 'old.mp3'), createdAt: '2024-01-01T00:00:00Z' },
+        { ...makeTranscription('new', 'new.mp3'), createdAt: '2024-02-01T00:00:00Z' },
+      ]);
+
+      const result = await service.getTranscriptions();
+
+      expect(result[0].id).toBe('new');
+      expect(result[1].id).toBe('old');
+      // サマリーのみ（speakers・words・utterancesは含まない）
+      expect((result[0] as any).speakers).toBeUndefined();
+    });
+  });
+
+  describe('getTranscription', () => {
+    it('IDで文字起こし結果を取得する', async () => {
+      const transcription = makeTranscription();
+      store.findById.mockResolvedValue(transcription);
+
+      const result = await service.getTranscription('test-audio');
+
+      expect(result).toEqual(transcription);
+    });
+
+    it('存在しないIDはNotFoundExceptionをスロー', async () => {
+      store.findById.mockResolvedValue(null);
+
+      await expect(service.getTranscription('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateSpeakers', () => {
+    it('話者名を更新して発話セグメントにも反映する', async () => {
+      const transcription = makeTranscription();
+      store.findById.mockResolvedValue(transcription);
+      store.save.mockResolvedValue(undefined);
+
+      const result = await service.updateSpeakers('test-audio', [
+        { id: 'speaker_0', name: '田中さん' },
+      ]);
+
+      expect(result.speakers[0].name).toBe('田中さん');
+      // 発話セグメントの話者名も更新されている
+      expect(result.utterances[0].speakerName).toBe('田中さん');
+      // 更新対象でない話者は変わらない
+      expect(result.speakers[1].name).toBe('Bさん');
+    });
+
+    it('文字起こしが存在しない場合はNotFoundExceptionをスロー', async () => {
+      store.findById.mockResolvedValue(null);
+
+      await expect(
+        service.updateSpeakers('missing', [{ id: 'speaker_0', name: '田中さん' }]),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getResumableJobs / getChunkedJobStatus / findActiveJob', () => {
+    it('再開可能ジョブ一覧を取得する', async () => {
+      const jobs = [{ id: 'job-1' } as any];
+      chunkedTranscriptionService.getResumableJobs.mockResolvedValue(jobs);
+
+      expect(await service.getResumableJobs()).toEqual(jobs);
+    });
+
+    it('ジョブの進捗を取得する', async () => {
+      const job = { id: 'job-1', status: 'transcribing' } as any;
+      chunkedTranscriptionService.getJobStatus.mockResolvedValue(job);
+
+      expect(await service.getChunkedJobStatus('job-1')).toEqual(job);
+    });
+
+    it('ファイル名でアクティブジョブを検索する', async () => {
+      const job = { id: 'job-1', audioFileName: 'test.mp3' } as any;
+      chunkedTranscriptionService.findActiveJobByFileName.mockResolvedValue(job);
+
+      expect(await service.findActiveJob('test.mp3')).toEqual(job);
+    });
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:run": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,8 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest",
-    "test:run": "vitest run"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/frontend/src/components/__tests__/PreviousUtterancePopup.test.tsx
+++ b/frontend/src/components/__tests__/PreviousUtterancePopup.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PreviousUtterancePopup } from '../PreviousUtterancePopup';
+import type { Speaker, Utterance } from '../../types';
+
+const sampleUtterance: Utterance = {
+  speakerId: 'speaker_1',
+  speakerName: 'Bさん',
+  start: 65,
+  end: 125,
+  text: '世界について話しています',
+  words: [],
+};
+
+const sampleSpeaker: Speaker = {
+  id: 'speaker_1',
+  name: 'Bさん',
+  color: '#EF4444',
+};
+
+const defaultProps = {
+  utterance: sampleUtterance,
+  speaker: sampleSpeaker,
+  onClose: vi.fn(),
+};
+
+describe('PreviousUtterancePopup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('「直前の発話」タイトルを表示する', () => {
+    render(<PreviousUtterancePopup {...defaultProps} />);
+    expect(screen.getByText('直前の発話')).toBeInTheDocument();
+  });
+
+  it('話者名を表示する', () => {
+    render(<PreviousUtterancePopup {...defaultProps} />);
+    expect(screen.getByText('Bさん')).toBeInTheDocument();
+  });
+
+  it('発話テキストを表示する', () => {
+    render(<PreviousUtterancePopup {...defaultProps} />);
+    expect(screen.getByText('世界について話しています')).toBeInTheDocument();
+  });
+
+  it('時刻を mm:ss - mm:ss 形式で表示する', () => {
+    render(<PreviousUtterancePopup {...defaultProps} />);
+    // 65秒 = 1:05、125秒 = 2:05
+    expect(screen.getByText('1:05 - 2:05')).toBeInTheDocument();
+  });
+
+  it('話者の色をborderLeftColorに適用する', () => {
+    const { container } = render(<PreviousUtterancePopup {...defaultProps} />);
+    const content = container.querySelector('.previous-utterance-popup-content');
+    expect(content).toHaveStyle({ borderLeftColor: '#EF4444' });
+  });
+
+  it('speakerがundefinedの場合はデフォルト色を使う', () => {
+    const { container } = render(
+      <PreviousUtterancePopup {...defaultProps} speaker={undefined} />,
+    );
+    const content = container.querySelector('.previous-utterance-popup-content');
+    expect(content).toHaveStyle({ borderLeftColor: '#6B7280' });
+  });
+
+  it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    render(<PreviousUtterancePopup {...defaultProps} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('オーバーレイをクリックするとonCloseが呼ばれる', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <PreviousUtterancePopup {...defaultProps} onClose={onClose} />,
+    );
+
+    const overlay = container.querySelector('.previous-utterance-overlay');
+    fireEvent.click(overlay!);
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('ポップアップ内クリックはonCloseを呼ばない（イベント伝播を止める）', () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <PreviousUtterancePopup {...defaultProps} onClose={onClose} />,
+    );
+
+    const popup = container.querySelector('.previous-utterance-popup');
+    fireEvent.click(popup!);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/SpeakerNameEditor.test.tsx
+++ b/frontend/src/components/__tests__/SpeakerNameEditor.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SpeakerNameEditor } from '../SpeakerNameEditor';
+import { updateSpeakerNames } from '../../api/client';
+import type { Speaker, Transcription } from '../../types';
+
+vi.mock('../../api/client');
+
+const sampleSpeakers: Speaker[] = [
+  { id: 'speaker_0', name: 'Aさん', color: '#3B82F6' },
+  { id: 'speaker_1', name: 'Bさん', color: '#EF4444' },
+];
+
+const updatedTranscription: Transcription = {
+  id: 'test',
+  audioFileName: 'test.mp3',
+  createdAt: '2024-01-01T00:00:00Z',
+  languageCode: 'ja',
+  fullText: '',
+  speakers: [
+    { id: 'speaker_0', name: '田中さん', color: '#3B82F6' },
+    { id: 'speaker_1', name: 'Bさん', color: '#EF4444' },
+  ],
+  words: [],
+  utterances: [],
+};
+
+const defaultProps = {
+  transcriptionId: 'test',
+  speakers: sampleSpeakers,
+  onUpdate: vi.fn(),
+};
+
+describe('SpeakerNameEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('話者名の入力フィールドを表示する', () => {
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toHaveValue('Aさん');
+    expect(inputs[1]).toHaveValue('Bさん');
+  });
+
+  it('「保存」ボタンを表示する', () => {
+    render(<SpeakerNameEditor {...defaultProps} />);
+    expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument();
+  });
+
+  it('話者の色のドットを表示する', () => {
+    const { container } = render(<SpeakerNameEditor {...defaultProps} />);
+    const dots = container.querySelectorAll('.speaker-color-dot');
+    expect(dots).toHaveLength(2);
+    expect(dots[0]).toHaveStyle({ backgroundColor: '#3B82F6' });
+    expect(dots[1]).toHaveStyle({ backgroundColor: '#EF4444' });
+  });
+
+  it('入力フィールドで話者名を編集できる', async () => {
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], '田中さん');
+
+    expect(inputs[0]).toHaveValue('田中さん');
+  });
+
+  it('保存ボタンをクリックするとupdateSpeakerNamesが呼ばれる', async () => {
+    vi.mocked(updateSpeakerNames).mockResolvedValue(updatedTranscription);
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    expect(updateSpeakerNames).toHaveBeenCalledWith('test', [
+      { id: 'speaker_0', name: 'Aさん' },
+      { id: 'speaker_1', name: 'Bさん' },
+    ]);
+  });
+
+  it('保存成功後にonUpdateが呼ばれる', async () => {
+    vi.mocked(updateSpeakerNames).mockResolvedValue(updatedTranscription);
+    const onUpdate = vi.fn();
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} onUpdate={onUpdate} />);
+
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith(updatedTranscription);
+    });
+  });
+
+  it('保存中はボタンが「保存中...」になり無効化される', async () => {
+    vi.mocked(updateSpeakerNames).mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    expect(screen.getByRole('button', { name: '保存中...' })).toBeDisabled();
+  });
+
+  it('保存完了後にボタンが「保存」に戻る', async () => {
+    vi.mocked(updateSpeakerNames).mockResolvedValue(updatedTranscription);
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '保存' })).toBeEnabled();
+    });
+  });
+
+  it('名前を変更して保存すると変更後の名前が送信される', async () => {
+    vi.mocked(updateSpeakerNames).mockResolvedValue(updatedTranscription);
+    const user = userEvent.setup();
+    render(<SpeakerNameEditor {...defaultProps} />);
+
+    const inputs = screen.getAllByRole('textbox');
+    await user.clear(inputs[0]);
+    await user.type(inputs[0], '田中さん');
+    await user.click(screen.getByRole('button', { name: '保存' }));
+
+    expect(updateSpeakerNames).toHaveBeenCalledWith('test', [
+      { id: 'speaker_0', name: '田中さん' },
+      { id: 'speaker_1', name: 'Bさん' },
+    ]);
+  });
+});

--- a/frontend/src/components/__tests__/TranscriptionView.test.tsx
+++ b/frontend/src/components/__tests__/TranscriptionView.test.tsx
@@ -1,0 +1,235 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TranscriptionView } from '../TranscriptionView';
+import type { Transcription } from '../../types';
+
+vi.mock('../UtteranceBlock', () => ({
+  UtteranceBlock: ({
+    utterance,
+    clickable,
+    onBlockClick,
+    onTimeClick,
+  }: {
+    utterance: { speakerName: string; text: string; start: number };
+    clickable?: boolean;
+    onBlockClick?: () => void;
+    onTimeClick?: (t: number) => void;
+  }) => (
+    <div
+      data-testid={`utterance-${utterance.speakerName}`}
+      onClick={clickable ? onBlockClick : undefined}
+    >
+      <span>{utterance.speakerName}</span>
+      <span>{utterance.text}</span>
+      <button onClick={() => onTimeClick?.(utterance.start)}>時刻</button>
+    </div>
+  ),
+}));
+
+vi.mock('../PreviousUtterancePopup', () => ({
+  PreviousUtterancePopup: ({
+    utterance,
+    onClose,
+  }: {
+    utterance: { text: string };
+    onClose: () => void;
+  }) => (
+    <div data-testid="popup">
+      <span>{utterance.text}</span>
+      <button onClick={onClose}>閉じる</button>
+    </div>
+  ),
+}));
+
+/** テスト用の文字起こしデータ */
+const sampleTranscription: Transcription = {
+  id: 'test',
+  audioFileName: 'test.mp3',
+  createdAt: '2024-01-01T00:00:00Z',
+  languageCode: 'ja',
+  fullText: 'こんにちは 世界 AIについて',
+  speakers: [
+    { id: 'speaker_0', name: 'Aさん', color: '#3B82F6' },
+    { id: 'speaker_1', name: 'Bさん', color: '#EF4444' },
+  ],
+  words: [],
+  utterances: [
+    {
+      speakerId: 'speaker_0',
+      speakerName: 'Aさん',
+      start: 0,
+      end: 1,
+      text: 'こんにちは',
+      words: [],
+    },
+    {
+      speakerId: 'speaker_1',
+      speakerName: 'Bさん',
+      start: 1,
+      end: 2,
+      text: '世界',
+      words: [],
+    },
+    {
+      speakerId: 'speaker_0',
+      speakerName: 'Aさん',
+      start: 2,
+      end: 3,
+      text: 'AIについて',
+      words: [],
+    },
+  ],
+};
+
+const defaultProps = {
+  transcription: sampleTranscription,
+  highlightedKeywords: new Set<string>(),
+  filterActive: false,
+};
+
+describe('TranscriptionView', () => {
+  it('全発話を表示する', () => {
+    render(<TranscriptionView {...defaultProps} />);
+
+    expect(screen.getByText('こんにちは')).toBeInTheDocument();
+    expect(screen.getByText('世界')).toBeInTheDocument();
+    expect(screen.getByText('AIについて')).toBeInTheDocument();
+  });
+
+  it('「文字起こし結果」ヘッダーを表示する', () => {
+    render(<TranscriptionView {...defaultProps} />);
+    expect(screen.getByText('文字起こし結果')).toBeInTheDocument();
+  });
+
+  describe('話者フィルター', () => {
+    it('selectedSpeakerIdを指定すると対象話者の発話のみ表示する', () => {
+      render(<TranscriptionView {...defaultProps} selectedSpeakerId="speaker_0" />);
+
+      expect(screen.getAllByText('Aさん')).toHaveLength(2);
+      expect(screen.queryByText('世界')).not.toBeInTheDocument();
+    });
+
+    it('フィルター件数をインフォメーションとして表示する', () => {
+      render(<TranscriptionView {...defaultProps} selectedSpeakerId="speaker_0" />);
+
+      expect(screen.getByText(/2件の発話を表示中（全3件）/)).toBeInTheDocument();
+    });
+  });
+
+  describe('キーワードフィルター', () => {
+    it('filterActive=trueのときキーワードにマッチする発話のみ表示する', () => {
+      render(
+        <TranscriptionView
+          {...defaultProps}
+          highlightedKeywords={new Set(['AI'])}
+          filterActive={true}
+        />,
+      );
+
+      expect(screen.getByText('AIについて')).toBeInTheDocument();
+      expect(screen.queryByText('こんにちは')).not.toBeInTheDocument();
+      expect(screen.queryByText('世界')).not.toBeInTheDocument();
+    });
+
+    it('filterActive=falseのときキーワードがあっても全発話を表示する', () => {
+      render(
+        <TranscriptionView
+          {...defaultProps}
+          highlightedKeywords={new Set(['AI'])}
+          filterActive={false}
+        />,
+      );
+
+      expect(screen.getByText('こんにちは')).toBeInTheDocument();
+      expect(screen.getByText('世界')).toBeInTheDocument();
+      expect(screen.getByText('AIについて')).toBeInTheDocument();
+    });
+  });
+
+  describe('単語選択', () => {
+    it('単語選択時に選択数を表示する', () => {
+      const { container } = render(<TranscriptionView {...defaultProps} />);
+      // UtteranceBlockはモックなので直接toggleWordを呼べないため
+      // selectedWordsの初期状態（選択なし）を確認
+      expect(container.querySelector('.selection-info')).toBeNull();
+    });
+  });
+
+  describe('コンテキスト選択モード', () => {
+    it('contextSelectMode=trueのときチェックボックスを表示する', () => {
+      const { container } = render(
+        <TranscriptionView
+          {...defaultProps}
+          contextSelectMode={true}
+          selectedUtteranceIndices={new Set()}
+          onToggleUtteranceSelection={vi.fn()}
+        />,
+      );
+
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      expect(checkboxes).toHaveLength(3);
+    });
+
+    it('チェックボックスをクリックするとonToggleUtteranceSelectionが呼ばれる', () => {
+      const onToggle = vi.fn();
+      const { container } = render(
+        <TranscriptionView
+          {...defaultProps}
+          contextSelectMode={true}
+          selectedUtteranceIndices={new Set()}
+          onToggleUtteranceSelection={onToggle}
+        />,
+      );
+
+      const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+      fireEvent.click(checkboxes[0]);
+
+      expect(onToggle).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('直前発話ポップアップ', () => {
+    it('話者フィルター中に別話者の発話ブロックをクリックするとポップアップが表示される', () => {
+      render(
+        <TranscriptionView
+          {...defaultProps}
+          selectedSpeakerId="speaker_0"
+        />,
+      );
+
+      // speaker_0の2番目の発話（index=2、直前はspeaker_1）をクリック
+      const utteranceBlocks = screen.getAllByTestId(/^utterance-/);
+      // speaker_0の2番目のブロック（index=2）
+      fireEvent.click(utteranceBlocks[1]);
+
+      expect(screen.getByTestId('popup')).toBeInTheDocument();
+      expect(screen.getByText('世界')).toBeInTheDocument();
+    });
+
+    it('ポップアップの「閉じる」ボタンでポップアップが消える', () => {
+      render(
+        <TranscriptionView
+          {...defaultProps}
+          selectedSpeakerId="speaker_0"
+        />,
+      );
+
+      const utteranceBlocks = screen.getAllByTestId(/^utterance-/);
+      fireEvent.click(utteranceBlocks[1]);
+      expect(screen.getByTestId('popup')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('閉じる'));
+      expect(screen.queryByTestId('popup')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('onTimeClick', () => {
+    it('onTimeClickが渡されるとUtteranceBlockに伝播する', () => {
+      const onTimeClick = vi.fn();
+      render(<TranscriptionView {...defaultProps} onTimeClick={onTimeClick} />);
+
+      fireEvent.click(screen.getAllByText('時刻')[0]);
+
+      expect(onTimeClick).toHaveBeenCalledWith(0);
+    });
+  });
+});

--- a/frontend/src/components/__tests__/UtteranceBlock.test.tsx
+++ b/frontend/src/components/__tests__/UtteranceBlock.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { UtteranceBlock } from '../UtteranceBlock';
+import type { Utterance, Speaker } from '../../types';
+
+vi.mock('../WordSpan', () => ({
+  WordSpan: ({ word, onClick, onTimeClick }: {
+    word: { text: string; type: string; start: number; end: number; speakerId: string };
+    isSelected: boolean;
+    highlightedKeywords: Set<string>;
+    onClick: () => void;
+    onTimeClick?: (t: number) => void;
+  }) => (
+    <span data-testid={`word-${word.text}`} onClick={() => { onClick(); onTimeClick?.(word.start); }}>
+      {word.text}
+    </span>
+  ),
+}));
+
+/** テスト用の発話データ */
+const sampleUtterance: Utterance = {
+  speakerId: 'speaker_0',
+  speakerName: 'Aさん',
+  start: 65,
+  end: 125,
+  text: 'こんにちは',
+  words: [
+    { text: 'こんにちは', start: 65, end: 70, type: 'word', speakerId: 'speaker_0' },
+  ],
+};
+
+const sampleSpeaker: Speaker = {
+  id: 'speaker_0',
+  name: 'Aさん',
+  color: '#3B82F6',
+};
+
+const defaultProps = {
+  utterance: sampleUtterance,
+  speaker: sampleSpeaker,
+  selectedWords: new Set<number>(),
+  highlightedKeywords: new Set<string>(),
+  wordIndexOffset: 0,
+  onWordClick: vi.fn(),
+};
+
+describe('UtteranceBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('話者名を表示する', () => {
+    render(<UtteranceBlock {...defaultProps} />);
+    expect(screen.getByText('Aさん')).toBeInTheDocument();
+  });
+
+  it('開始・終了時刻を mm:ss - mm:ss 形式で表示する', () => {
+    render(<UtteranceBlock {...defaultProps} />);
+    // 65秒 = 1:05、125秒 = 2:05
+    expect(screen.getByText('1:05 - 2:05')).toBeInTheDocument();
+  });
+
+  it('話者の色をborderLeftColorに適用する', () => {
+    const { container } = render(<UtteranceBlock {...defaultProps} />);
+    const block = container.querySelector('.utterance-block');
+    expect(block).toHaveStyle({ borderLeftColor: '#3B82F6' });
+  });
+
+  it('speakerがundefinedの場合はデフォルト色を使う', () => {
+    const { container } = render(<UtteranceBlock {...defaultProps} speaker={undefined} />);
+    const block = container.querySelector('.utterance-block');
+    expect(block).toHaveStyle({ borderLeftColor: '#6B7280' });
+  });
+
+  it('単語コンポーネントが表示される', () => {
+    render(<UtteranceBlock {...defaultProps} />);
+    expect(screen.getByTestId('word-こんにちは')).toBeInTheDocument();
+  });
+
+  it('単語クリックでonWordClickが呼ばれる', () => {
+    const onWordClick = vi.fn();
+    render(<UtteranceBlock {...defaultProps} onWordClick={onWordClick} wordIndexOffset={5} />);
+
+    fireEvent.click(screen.getByTestId('word-こんにちは'));
+
+    // wordIndexOffset(5) + word index(0) = 5
+    expect(onWordClick).toHaveBeenCalledWith(5);
+  });
+
+  it('clickable=trueでブロッククリック時にonBlockClickが呼ばれる', () => {
+    const onBlockClick = vi.fn();
+    const { container } = render(
+      <UtteranceBlock {...defaultProps} clickable onBlockClick={onBlockClick} />,
+    );
+    const block = container.querySelector('.utterance-block');
+
+    fireEvent.click(block!);
+
+    expect(onBlockClick).toHaveBeenCalled();
+  });
+
+  it('clickable=falseの場合はブロッククリックが無効', () => {
+    const onBlockClick = vi.fn();
+    const { container } = render(
+      <UtteranceBlock {...defaultProps} clickable={false} onBlockClick={onBlockClick} />,
+    );
+    const block = container.querySelector('.utterance-block');
+
+    fireEvent.click(block!);
+
+    expect(onBlockClick).not.toHaveBeenCalled();
+  });
+
+  it('onTimeClickが渡された場合、時刻クリックでonTimeClickが呼ばれる', () => {
+    const onTimeClick = vi.fn();
+    render(<UtteranceBlock {...defaultProps} onTimeClick={onTimeClick} />);
+
+    fireEvent.click(screen.getByText('1:05 - 2:05'));
+
+    expect(onTimeClick).toHaveBeenCalledWith(65);
+  });
+
+  it('onTimeClickが渡されていない場合、時刻クリックは何もしない', () => {
+    render(<UtteranceBlock {...defaultProps} onTimeClick={undefined} />);
+    // エラーなく動作すること
+    fireEvent.click(screen.getByText('1:05 - 2:05'));
+  });
+});

--- a/frontend/src/utils/transcription.test.ts
+++ b/frontend/src/utils/transcription.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { formatTime, formatDuration, estimateCredits, CREDITS_PER_MINUTE } from './transcription';
+import type { ChunkedJobDetail } from '../api/client';
+
+describe('formatTime', () => {
+  it('秒を mm:ss 形式にフォーマットする', () => {
+    expect(formatTime(0)).toBe('0:00');
+    expect(formatTime(59)).toBe('0:59');
+    expect(formatTime(60)).toBe('1:00');
+    expect(formatTime(90)).toBe('1:30');
+    expect(formatTime(3661)).toBe('61:01');
+  });
+
+  it('1桁の秒は0埋めする', () => {
+    expect(formatTime(61)).toBe('1:01');
+    expect(formatTime(609)).toBe('10:09');
+  });
+
+  it('小数秒は切り捨てる', () => {
+    expect(formatTime(1.9)).toBe('0:01');
+  });
+});
+
+describe('formatDuration', () => {
+  it('1時間未満は「X分Y秒」形式', () => {
+    expect(formatDuration(90)).toBe('1分30秒');
+    expect(formatDuration(3599)).toBe('59分59秒');
+  });
+
+  it('1分未満は「X秒」形式', () => {
+    expect(formatDuration(45)).toBe('45秒');
+    expect(formatDuration(0)).toBe('0秒');
+  });
+
+  it('1時間以上は「X時間Y分」形式', () => {
+    expect(formatDuration(3600)).toBe('1時間');
+    expect(formatDuration(3660)).toBe('1時間1分');
+    expect(formatDuration(7200)).toBe('2時間');
+    expect(formatDuration(7320)).toBe('2時間2分');
+  });
+
+  it('端数の秒は四捨五入する', () => {
+    expect(formatDuration(30.4)).toBe('30秒');
+    expect(formatDuration(30.5)).toBe('31秒');
+  });
+});
+
+describe('estimateCredits', () => {
+  const makeJob = (totalChunks: number, completedCount: number, chunkDurationSec = 600): ChunkedJobDetail => ({
+    id: 'job-1',
+    audioFileName: 'test.mp3',
+    createdAt: '2024-01-01T00:00:00Z',
+    status: 'transcribing',
+    totalDurationSec: totalChunks * chunkDurationSec,
+    chunkDurationSec,
+    totalChunks,
+    currentChunkIndex: completedCount,
+    completedChunks: Array.from({ length: completedCount }, (_, i) => ({
+      index: i,
+      chunkFileName: `chunk-${i}.mp3`,
+      startTimeSec: i * chunkDurationSec,
+      text: `テキスト${i}`,
+      languageCode: 'ja',
+    })),
+    updatedAt: '2024-01-01T00:00:00Z',
+    isProcessing: false,
+  });
+
+  it('残りチャンクから必要クレジットを計算する', () => {
+    const job = makeJob(6, 3, 600);
+    // 残り3チャンク × 600秒/チャンク = 1800秒 = 30分 × 40クレジット/分 = 1200
+    expect(estimateCredits(job)).toBe(1200);
+  });
+
+  it('全チャンク完了時は0クレジット', () => {
+    const job = makeJob(3, 3, 600);
+    expect(estimateCredits(job)).toBe(0);
+  });
+
+  it('chunkDurationSecのデフォルトは600秒', () => {
+    const job = makeJob(2, 1);
+    // 残り1チャンク × 600秒 = 600秒 = 10分 × 40 = 400
+    expect(estimateCredits(job)).toBe(400);
+  });
+
+  it('CREDITS_PER_MINUTEは40', () => {
+    expect(CREDITS_PER_MINUTE).toBe(40);
+  });
+});


### PR DESCRIPTION
## Summary

- バックエンド（Jest）にテストスイートを9本追加し、カバレッジを27% → 大幅向上
- フロントエンド（Vitest）にテストスイートを4本追加し、41件 → 71件に増加
- Jest設定に `silent` + `verbose` + `setupFilesAfterEnv` を追加してNestJSログをテスト時に抑制
- フロントエンドの `npm test` をウォッチモードから一度だけ実行（`vitest run`）に変更

### 追加したテスト（バックエンド）

| ファイル | テスト数 |
|---|---|
| `TranscriptionService` | 21件 |
| `InterviewService` | 12件 |
| `AnalysisLogStorage` | 6件 |
| `LocalAudioStorage` | 11件 |
| `LocalTranscriptionStorage` | 9件 |
| `LocalDocumentStorage` | 10件 |
| `PodcastService` | 8件 |
| `DeepSearchService` | 10件 |
| `SettingsController` | 3件 |

### 追加したテスト（フロントエンド）

| ファイル | テスト数 |
|---|---|
| `utils/transcription.ts` | 11件 |
| `UtteranceBlock` | 10件 |
| `TranscriptionView` | 12件 |
| `SpeakerNameEditor` | 9件 |
| `PreviousUtterancePopup` | 9件 |

## Test plan

- [ ] `backend-test` CI が通ること
- [ ] `frontend-test` CI が通ること