### PR TITLE
feat: 話者分離の最大話者数を2人に制限する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,17 @@ ai-speak-trace/
 - Amazon Bedrock Titan Embeddings V2によるベクトル検索（PDF）
 - 検索結果をClaudeで統合分析
 
+## 開発環境
+
+アプリの動作確認は**ルートディレクトリから `npm run dev` 一択**で行う。
+
+```bash
+# ai-speak-trace/ ルートディレクトリで実行
+npm run dev
+```
+
+`frontend/` や `backend/` で個別に起動しない。バックエンドはポート0でランダム起動し、`scripts/dev.mjs` 経由でポートをフロントエンドに伝える仕組みのため、個別起動するとプロキシ接続が失敗する。
+
 ## 前提条件
 
 - 文字起こしは日本語

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ tar xzf ~/Downloads/AI.Speak.Trace_*.app.tar.gz -C /Applications
 
 **Podcastアプリから取り込む場合**
 
-macOSにはPodcastアプリがプリインストールされています。エピソードをダウンロードしてから、本アプリにアップロードしてください。
+macOSにはPodcastアプリがプリインストールされています。エピソードをダウンロードしてから、本アプリで取り込んでください。
 
 - [Podcastでエピソードを保存する/ダウンロードする（Mac）](https://support.apple.com/ja-jp/guide/podcasts/poda4f6be01/mac)
 - [Podcastユーザガイド（Mac）](https://support.apple.com/ja-jp/guide/podcasts/welcome/mac)
@@ -88,6 +88,8 @@ open ~/Library/Application\ Support/io.github.saicologic.ai-speak-trace/data
 ## 使い方
 
 ### 1. ファイルアップロード・文字起こし・結果確認
+
+> **話者数について:** 文字起こしの話者分離は最大2人までを対象としています。3人以上の音声は動作保証外です。
 
 1. 左サイドバーの「音声ファイルの文字起こし」をクリック
 2. 音声ファイルを選択し、クレジット残量を確認して「文字起こしを実行」

--- a/backend/src/transcription/elevenlabs.service.ts
+++ b/backend/src/transcription/elevenlabs.service.ts
@@ -51,6 +51,7 @@ export class ElevenLabsService {
     form.append('model_id', 'scribe_v2');
     form.append('language_code', 'ja');
     form.append('diarize', 'true');
+    form.append('num_speakers', '2');
     form.append('timestamps_granularity', 'word');
     form.append('tag_audio_events', 'true');
 


### PR DESCRIPTION
## 概要

- ElevenLabs Scribe v2 APIに `num_speakers=2` を追加し、話者分離の上限を2人に設定
- READMEに最大話者数2人・3人以上は動作保証外である旨を追記
- READMEのPodcast説明の「アップロード」を「取り込む」に修正
- CLAUDE.mdに開発環境セクションを追加（`npm run dev` 一択で起動する旨と個別起動禁止の理由を明記）

## 変更ファイル

- `backend/src/transcription/elevenlabs.service.ts` — `num_speakers: '2'` を追加
- `README.md` — 話者数制限の注記追加、Podcast説明の文言修正
- `CLAUDE.md` — 開発環境セクション追加

## Test plan

- [x] CI自動チェック（`backend-test`, `frontend-test`）が通ること
- [x] 2人の会話音声を文字起こしし、話者が2人で分離されること
- [ ] 1人の音声を文字起こしし、話者が1人で返ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)