### PR TITLE
fix: release.ymlのリリースノート抽出を「## Summary」セクションにも対応する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,11 @@ jobs:
             --json body \
             --jq '.[0].body // ""')
 
-          # "## 変更内容" セクションを抽出し "## " で始まる次のセクションの直前まで取得
-          CHANGES=$(echo "$PR_BODY" | awk '/^## 変更内容/{found=1; next} found && /^## /{exit} found{print}')
+          # "## 変更内容" または "## Summary" セクションを抽出し "## " で始まる次のセクションの直前まで取得
+          CHANGES=$(echo "$PR_BODY" | awk '/^## (変更内容|Summary)/{found=1; next} found && /^## /{exit} found{print}')
 
           if [ -z "$CHANGES" ]; then
-            echo "::error::release: v${VERSION} のPRが見つからないか、「## 変更内容」セクションがありません"
+            echo "::error::release: v${VERSION} のPRが見つからないか、「## 変更内容」または「## Summary」セクションがありません"
             exit 1
           fi
 


### PR DESCRIPTION
## 変更内容

- `release.yml` のリリースノート抽出で `## 変更内容` に加えて `## Summary` セクションも受け入れるよう修正
- Claude Codeが英語テンプレートで生成したリリースPRで `## Summary` を使った場合にCIが失敗する問題を解消

## 背景

PR #136（release: v0.5.12）が Claude Code の英語テンプレートで生成されたため `## Summary` セクションを使っており、`## 変更内容` を必須とするリリースノート生成ステップが失敗した。

## Test plan

- [x] CI自動チェック（`backend-test`, `frontend-test`）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)