### PR TITLE
feat: ffmpegをアプリにバンドルしてユーザーのインストール不要にする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,18 @@ jobs:
       - name: バックエンドsidecarバイナリ生成
         run: npm run pkg:backend
 
+      # ffmpeg静的バイナリをsrc-tauri/binaries/に配置
+      - name: ffmpegバイナリ配置
+        run: |
+          node -e "
+            const fs = require('fs');
+            const p = require('ffmpeg-static');
+            fs.copyFileSync(p, '../src-tauri/binaries/ffmpeg-aarch64-apple-darwin');
+            fs.chmodSync('../src-tauri/binaries/ffmpeg-aarch64-apple-darwin', 0o755);
+            console.log('ffmpeg配置完了:', p);
+          "
+        working-directory: backend
+
       # release/vX.Y.Z PRの「変更内容」セクションをリリースノートに使用
       - name: リリースノート生成
         id: release_notes

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -46,6 +46,7 @@
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.2",
+        "ffmpeg-static": "^5.3.0",
         "globals": "^16.0.0",
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
@@ -1836,6 +1837,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -6903,6 +6920,13 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -7649,6 +7673,16 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -8261,6 +8295,23 @@
         }
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8865,6 +8916,23 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -10898,6 +10966,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -66,6 +66,7 @@
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-prettier": "^5.2.2",
+    "ffmpeg-static": "^5.3.0",
     "globals": "^16.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
@@ -106,6 +107,8 @@
     "testEnvironment": "node",
     "silent": true,
     "verbose": true,
-    "setupFilesAfterEnv": ["<rootDir>/jest.setup.ts"]
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.ts"
+    ]
   }
 }

--- a/backend/src/transcription/audio-splitter.service.ts
+++ b/backend/src/transcription/audio-splitter.service.ts
@@ -15,35 +15,48 @@ export const DEFAULT_CHUNK_DURATION_SEC = 600;
 export class AudioSplitterService {
   private readonly logger = new Logger(AudioSplitterService.name);
 
-  /** ffmpegがインストールされているか確認 */
+  /**
+   * 使用するffmpegバイナリのパスを返す
+   * 環境変数 FFMPEG_PATH が設定されている場合はそちらを優先（Tauriバンドル時）
+   */
+  private getFfmpegPath(): string {
+    return process.env.FFMPEG_PATH ?? 'ffmpeg';
+  }
+
+  /** ffmpegが利用可能か確認 */
   async checkFfmpegAvailable(): Promise<boolean> {
     try {
-      await execFileAsync('ffmpeg', ['-version']);
+      await execFileAsync(this.getFfmpegPath(), ['-version']);
       return true;
     } catch {
       return false;
     }
   }
 
-  /** ffprobeで音声ファイルの長さ（秒）を取得 */
+  /** ffmpegで音声ファイルの長さ（秒）を取得（ffprobe不要） */
   async getAudioDuration(filePath: string): Promise<number> {
+    const ffmpegPath = this.getFfmpegPath();
     try {
-      const { stdout } = await execFileAsync('ffprobe', [
-        '-v', 'quiet',
-        '-show_entries', 'format=duration',
-        '-of', 'csv=p=0',
-        filePath,
-      ]);
-      const duration = parseFloat(stdout.trim());
-      if (isNaN(duration)) {
-        throw new Error(`音声ファイルの長さを解析できません: ${stdout.trim()}`);
+      // ffmpegは-i指定のみだとexit code 1になるがstderrにduration情報が出る
+      const { stderr } = await execFileAsync(ffmpegPath, [
+        '-i', filePath,
+      ]).catch((err: { stderr?: string; code?: number }) => {
+        // exit code 1は正常（入力のみ指定時の期待動作）
+        if (err.stderr) return { stderr: err.stderr };
+        throw err;
+      }) as { stderr: string };
+
+      const match = /Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/.exec(stderr);
+      if (!match) {
+        throw new Error(`音声ファイルの長さを解析できません: ${filePath}`);
       }
-      return duration;
+      const hours = parseInt(match[1], 10);
+      const minutes = parseInt(match[2], 10);
+      const seconds = parseFloat(match[3]);
+      return hours * 3600 + minutes * 60 + seconds;
     } catch (error) {
       if (error instanceof Error && error.message.includes('ENOENT')) {
-        throw new Error(
-          'ffprobeが見つかりません。ffmpegをインストールしてください: brew install ffmpeg',
-        );
+        throw new Error('ffmpegが見つかりません');
       }
       throw error;
     }
@@ -63,11 +76,10 @@ export class AudioSplitterService {
     chunkDurationSec: number,
     outputDir: string,
   ): Promise<{ chunkFiles: string[]; totalDurationSec: number }> {
-    // ffmpegの存在確認
+    const ffmpegPath = this.getFfmpegPath();
+
     if (!(await this.checkFfmpegAvailable())) {
-      throw new Error(
-        'ffmpegがインストールされていません。Homebrew等でインストールしてください: brew install ffmpeg',
-      );
+      throw new Error('ffmpegが見つかりません');
     }
 
     // 出力ディレクトリを作成
@@ -95,7 +107,7 @@ export class AudioSplitterService {
       const chunkFileName = `chunk_${String(i).padStart(3, '0')}${ext}`;
       const chunkPath = path.join(outputDir, chunkFileName);
 
-      await execFileAsync('ffmpeg', [
+      await execFileAsync(ffmpegPath, [
         '-y',                          // 既存ファイルを上書き
         '-ss', String(startSec),       // 開始位置
         '-t', String(chunkDurationSec), // 切り出す長さ

--- a/backend/src/transcription/transcription.controller.spec.ts
+++ b/backend/src/transcription/transcription.controller.spec.ts
@@ -182,7 +182,7 @@ describe('TranscriptionController', () => {
 
     it('ffmpeg未インストールエラーは422を返す', async () => {
       mockTranscriptionService.transcribe.mockRejectedValueOnce(
-        new Error('ffprobeが見つかりません'),
+        new Error('ffmpegが見つかりません'),
       );
 
       await expect(

--- a/backend/src/transcription/transcription.controller.ts
+++ b/backend/src/transcription/transcription.controller.ts
@@ -169,14 +169,12 @@ export class TranscriptionController {
       // ffmpeg未インストールエラー
       if (
         error instanceof Error &&
-        (error.message.includes('ffprobeが見つかりません') ||
-          error.message.includes('ffmpegがインストールされていません'))
+        error.message.includes('ffmpegが見つかりません')
       ) {
         throw new HttpException(
           {
             code: 'FFMPEG_MISSING',
-            message:
-              'ffmpegがインストールされていません。ターミナルで以下のコマンドを実行してください:\nbrew install ffmpeg',
+            message: 'ffmpegが見つかりません。アプリを再インストールしてください。',
           },
           HttpStatus.UNPROCESSABLE_ENTITY,
         );

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,8 +74,16 @@ pub fn run() {
                     .join("Library/Group Containers/243LU875E5.groups.com.apple.podcasts/Library/Cache");
                 println!("[tauri] PODCAST_CACHE_DIR={}", podcast_cache_dir.display());
 
+                // バンドルされたffmpegバイナリのパスを解決してNestJSへ渡す
+                // externalBinはContents/MacOS/に配置されるため、実行ファイルと同じディレクトリを参照する
+                let ffmpeg_path = std::env::current_exe()
+                    .expect("実行ファイルパスの取得に失敗")
+                    .parent()
+                    .expect("実行ファイルの親ディレクトリ取得に失敗")
+                    .join("ffmpeg");
+                println!("[tauri] FFMPEG_PATH={}", ffmpeg_path.display());
+
                 // sidecarはシェルを経由しないためPATHが最小限になる
-                // ffmpeg等の外部コマンドを利用するため、Homebrew等のパスを追加する
                 let system_path = std::env::var("PATH").unwrap_or_default();
                 let extra_paths = "/opt/homebrew/bin:/usr/local/bin";
                 let full_path = if system_path.is_empty() {
@@ -91,7 +99,8 @@ pub fn run() {
                     .env("PATH", &full_path)
                     .env("DATA_DIR", data_dir.to_string_lossy().to_string())
                     .env("SETTINGS_FILE", settings_file.to_string_lossy().to_string())
-                    .env("PODCAST_CACHE_DIR", podcast_cache_dir.to_string_lossy().to_string());
+                    .env("PODCAST_CACHE_DIR", podcast_cache_dir.to_string_lossy().to_string())
+                    .env("FFMPEG_PATH", ffmpeg_path.to_string_lossy().to_string());
 
                 let (mut rx, child) = sidecar
                     .spawn()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -34,7 +34,8 @@
       "icons/icon.ico"
     ],
     "externalBin": [
-      "binaries/nestjs-server"
+      "binaries/nestjs-server",
+      "binaries/ffmpeg"
     ],
     "macOS": {
       "signingIdentity": "Developer ID Application: SATORU MIKAMI (2M2QV9R792)"


### PR DESCRIPTION
## 変更内容

- ffmpeg-static（arm64静的ビルド済みバイナリ v6.0）をTauriのexternalBinとしてバンドル
- ffprobeをffmpegコマンドで代替（`ffmpeg -i`のstderrからDuration解析）
- `FFMPEG_PATH`環境変数でバンドルバイナリのパスをNestJSへ渡す
- CIビルド時もffmpeg-staticからバイナリを配置するステップをrelease.ymlに追加

## 背景

ユーザーがHomebrewでffmpegをインストールしていない環境や、ffmpegのバージョンアップで
ライブラリリンクが切れた環境（libx265のバージョン不一致等）でも文字起こしが失敗する
問題を解消する。

## Test plan

- [x] CI自動チェック: `backend-test`, `frontend-test`
- [x] `npm run build`（backendディレクトリで実行）が成功すること
- [x] ローカルにffmpegをアンインストールした状態でルートの `npm run build` が成功すること
- [x] ビルドされた `.app` の `Contents/MacOS/ffmpeg` にバイナリが含まれていること
- [x] ローカルにffmpegがない状態でビルドしたアプリで音声ファイルの文字起こしができること