### PR TITLE
feat: 要約画面のプロンプト・フィールド設計を改善し、バックエンドを責務別クラスに再設計する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ src-tauri/gen/
 
 # 開発時バックエンドポートファイル
 .backend-port
+
+# ローカル検証用スクリーンショット
+screenshot-*.png
+
+# Playwright MCPスナップショット
+.playwright-mcp/

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -54,6 +54,10 @@ data/documents/*
 !data/documents/.gitkeep
 data/document-metadata/*
 !data/document-metadata/.gitkeep
+data/analysis-logs/*
+!data/analysis-logs/.gitkeep
+data/summary-logs/*
+!data/summary-logs/.gitkeep
 
 # Runtime data
 pids

--- a/backend/src/claude/analysis.service.ts
+++ b/backend/src/claude/analysis.service.ts
@@ -1,70 +1,13 @@
 import { Injectable, Logger } from '@nestjs/common';
-import Anthropic from '@anthropic-ai/sdk';
-import axios from 'axios';
+import { ClaudeClientService } from './claude-client.service';
 import { AnalysisResult } from '../interview/types/interview.types';
 
-/** Claude API連携サービス */
+/** 会話分析・Web検索・ディープサーチ分析を担うサービス */
 @Injectable()
-export class ClaudeService {
-  private readonly logger = new Logger(ClaudeService.name);
+export class AnalysisService {
+  private readonly logger = new Logger(AnalysisService.name);
 
-  constructor() {}
-
-  /**
-   * pkg --jitless 環境では globalThis.fetch が壊れるため、
-   * axios を使った fetch 互換関数を Anthropic クライアントに渡す
-   */
-  private async axiosFetch(
-    input: RequestInfo | URL,
-    init?: RequestInit,
-  ): Promise<Response> {
-    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
-    const method = (init?.method ?? (typeof input !== 'string' && !(input instanceof URL) ? (input as Request).method : undefined) ?? 'GET').toUpperCase();
-
-    const headers: Record<string, string> = {};
-    if (init?.headers) {
-      const h = init.headers;
-      if (h instanceof Headers) {
-        h.forEach((v, k) => { headers[k] = v; });
-      } else if (Array.isArray(h)) {
-        h.forEach(([k, v]) => { headers[k] = v; });
-      } else {
-        Object.assign(headers, h);
-      }
-    }
-
-    const response = await axios({
-      url,
-      method,
-      headers,
-      data: init?.body ?? undefined,
-      responseType: 'arraybuffer',
-      validateStatus: () => true,
-      decompress: true,
-    });
-
-    const bodyBuffer = Buffer.from(response.data as ArrayBuffer);
-    const responseHeaders = new Headers();
-    Object.entries(response.headers).forEach(([k, v]) => {
-      if (v !== undefined && v !== null) {
-        responseHeaders.set(k, String(v));
-      }
-    });
-
-    return new Response(bodyBuffer, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: responseHeaders,
-    });
-  }
-
-  /** Anthropicクライアントを取得（設定画面からの変更を即時反映） */
-  private getClient(): Anthropic {
-    return new Anthropic({
-      apiKey: process.env.ANTHROPIC_API_KEY,
-      fetch: this.axiosFetch.bind(this),
-    });
-  }
+  constructor(private readonly claudeClient: ClaudeClientService) {}
 
   /** 質問生成プロンプトを構築 */
   buildGenerateQuestionsPrompt(
@@ -103,108 +46,6 @@ ${question}
 - 調査結果を簡潔にまとめてください（300〜500文字程度）`;
   }
 
-  /** キーワードから調査レポート用の質問文を生成 */
-  async generateQuestions(
-    keywords: string[],
-    speakerName: string,
-  ): Promise<string[]> {
-    this.logger.log(`質問生成開始: キーワード数=${keywords.length}`);
-
-    const prompt = this.buildGenerateQuestionsPrompt(keywords, speakerName);
-
-    const response = await this.getClient().messages.create({
-      model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 2048,
-      messages: [{ role: 'user', content: prompt }],
-    });
-
-    const text =
-      response.content[0].type === 'text' ? response.content[0].text : '';
-    const questions = text
-      .split('\n')
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-
-    this.logger.log(`質問生成完了: ${questions.length}件`);
-    return questions;
-  }
-
-  /** 質問文でWeb検索付き分析を実行 */
-  async analyze(
-    questions: string[],
-    keywords: string[],
-    speakerName: string,
-  ): Promise<AnalysisResult[]> {
-    this.logger.log(`分析開始: 質問数=${questions.length}`);
-
-    const results: AnalysisResult[] = [];
-
-    for (const question of questions) {
-      try {
-        const result = await this.analyzeQuestion(
-          question,
-          keywords,
-          speakerName,
-        );
-        results.push(result);
-      } catch (error) {
-        this.logger.error(`質問の分析に失敗: ${question}`, error);
-        results.push({
-          question,
-          answer: '分析中にエラーが発生しました。',
-          sources: [],
-        });
-      }
-    }
-
-    this.logger.log(`分析完了: ${results.length}件`);
-    return results;
-  }
-
-  /** 1つの質問に対してWeb検索付き分析を実行 */
-  private async analyzeQuestion(
-    question: string,
-    keywords: string[],
-    speakerName: string,
-  ): Promise<AnalysisResult> {
-    const prompt = this.buildAnalysisPrompt(question, keywords, speakerName);
-
-    const response = await this.getClient().messages.create({
-      model: 'claude-sonnet-4-5-20250929',
-      max_tokens: 4096,
-      tools: [
-        {
-          type: 'web_search_20250305',
-          name: 'web_search',
-          max_uses: 3,
-        },
-      ],
-      messages: [{ role: 'user', content: prompt }],
-    });
-
-    // レスポンスからテキストとソースURLを抽出
-    let answer = '';
-    const sources: { title: string; url: string }[] = [];
-
-    for (const block of response.content) {
-      if (block.type === 'text') {
-        answer += block.text;
-      }
-      if (block.type === 'web_search_tool_result') {
-        for (const searchResult of (block as any).content || []) {
-          if (searchResult.type === 'web_search_result') {
-            sources.push({
-              title: searchResult.title || searchResult.url,
-              url: searchResult.url,
-            });
-          }
-        }
-      }
-    }
-
-    return { question, answer, sources };
-  }
-
   /** 発言の文脈分析プロンプトを構築 */
   buildContextAnalysisPrompt(
     allUtterances: { speakerName: string; text: string }[],
@@ -236,6 +77,103 @@ ${targetList}
 ]`;
   }
 
+  /** キーワードから調査レポート用の質問文を生成 */
+  async generateQuestions(
+    keywords: string[],
+    speakerName: string,
+  ): Promise<string[]> {
+    this.logger.log(`質問生成開始: キーワード数=${keywords.length}`);
+
+    const prompt = this.buildGenerateQuestionsPrompt(keywords, speakerName);
+
+    const response = await this.claudeClient.getClient().messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text =
+      response.content[0].type === 'text' ? response.content[0].text : '';
+    const questions = text
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    this.logger.log(`質問生成完了: ${questions.length}件`);
+    return questions;
+  }
+
+  /** 質問文でWeb検索付き分析を実行 */
+  async analyze(
+    questions: string[],
+    keywords: string[],
+    speakerName: string,
+  ): Promise<AnalysisResult[]> {
+    this.logger.log(`分析開始: 質問数=${questions.length}`);
+
+    const results: AnalysisResult[] = [];
+
+    for (const question of questions) {
+      try {
+        const result = await this.analyzeQuestion(question, keywords, speakerName);
+        results.push(result);
+      } catch (error) {
+        this.logger.error(`質問の分析に失敗: ${question}`, error);
+        results.push({
+          question,
+          answer: '分析中にエラーが発生しました。',
+          sources: [],
+        });
+      }
+    }
+
+    this.logger.log(`分析完了: ${results.length}件`);
+    return results;
+  }
+
+  /** 1つの質問に対してWeb検索付き分析を実行 */
+  private async analyzeQuestion(
+    question: string,
+    keywords: string[],
+    speakerName: string,
+  ): Promise<AnalysisResult> {
+    const prompt = this.buildAnalysisPrompt(question, keywords, speakerName);
+
+    const response = await this.claudeClient.getClient().messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 4096,
+      tools: [
+        {
+          type: 'web_search_20250305',
+          name: 'web_search',
+          max_uses: 3,
+        },
+      ],
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    let answer = '';
+    const sources: { title: string; url: string }[] = [];
+
+    for (const block of response.content) {
+      if (block.type === 'text') {
+        answer += block.text;
+      }
+      if (block.type === 'web_search_tool_result') {
+        for (const searchResult of (block as any).content || []) {
+          if (searchResult.type === 'web_search_result') {
+            sources.push({
+              title: searchResult.title || searchResult.url,
+              url: searchResult.url,
+            });
+          }
+        }
+      }
+    }
+
+    return { question, answer, sources };
+  }
+
   /** 発言の文脈を分析 */
   async analyzeContext(
     allUtterances: { speakerName: string; text: string }[],
@@ -243,12 +181,9 @@ ${targetList}
   ): Promise<{ index: number; intent: string; topic: string }[]> {
     this.logger.log(`文脈分析開始: 対象=${targetIndices.length}件`);
 
-    const prompt = this.buildContextAnalysisPrompt(
-      allUtterances,
-      targetIndices,
-    );
+    const prompt = this.buildContextAnalysisPrompt(allUtterances, targetIndices);
 
-    const response = await this.getClient().messages.create({
+    const response = await this.claudeClient.getClient().messages.create({
       model: 'claude-sonnet-4-5-20250929',
       max_tokens: 4096,
       messages: [{ role: 'user', content: prompt }],
@@ -257,7 +192,6 @@ ${targetList}
     const text =
       response.content[0].type === 'text' ? response.content[0].text : '';
 
-    // JSONブロックを抽出してパース
     const jsonMatch = text.match(/\[[\s\S]*\]/);
     if (!jsonMatch) {
       this.logger.error('文脈分析のJSON抽出に失敗');
@@ -291,7 +225,7 @@ ${context}
 - Markdown形式で回答してください
 - 調査結果を簡潔にまとめてください（300〜500文字程度）`;
 
-    const response = await this.getClient().messages.create({
+    const response = await this.claudeClient.getClient().messages.create({
       model: 'claude-sonnet-4-5-20250929',
       max_tokens: 4096,
       tools: [
@@ -326,102 +260,13 @@ ${context}
     return { answer, sources };
   }
 
-  /** 要約プロンプトのデフォルトテンプレート（{{fullText}} を会話全文で置換して使う） */
-  static readonly DEFAULT_SUMMARY_PROMPT = `あなたは会議・インタビューの文字起こしを要約するアシスタントです。
-
-<conversation>
-{{fullText}}
-</conversation>
-
-<instructions>
-上記の会話を分析し、以下のJSON形式のみで出力してください。JSONの前後に説明文やコードブロック記号（\`\`\`）を含めないでください。
-
-{
-  "overview": "会話全体の概要を2〜3文で記述",
-  "key_points": [
-    { "topic": "トピック名", "summary": "要点を2〜3文で記述" }
-  ],
-  "decisions": ["決定事項1", "決定事項2"],
-  "actions": [
-    { "speaker": "話者名", "task": "タスク内容を動詞句で記述" }
-  ],
-  "open_questions": ["未解決の質問1", "未解決の質問2"]
-}
-
-- overview: 会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる
-- key_points: 会話で扱われた主なテーマを3〜5点。各トピックの要点を2〜3文で記述する
-- decisions: 会話中に明示的に合意・決定された事項を列挙する。なければ空配列 []
-- actions: 会話中に言及された次のステップを話者名と紐づけて列挙する。話者が不明な場合は「未定」とする。なければ空配列 []
-- open_questions: 結論が出なかった質問・持ち越し事項を列挙する。なければ空配列 []
-</instructions>`;
-
-  /** 要約で選択可能なモデル一覧（要約向き順） */
-  static readonly SUMMARY_MODELS = [
-    { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6（推奨）' },
-    {
-      id: 'claude-haiku-4-5-20251001',
-      label: 'claude-haiku-4-5-20251001（高速・低コスト）',
-    },
-    { id: 'claude-opus-4-7', label: 'claude-opus-4-7（高品質）' },
-  ];
-
-  /** 会話全文を要約してJSON構造で返す */
-  async summarize(
-    fullText: string,
-    model: string = 'claude-sonnet-4-6',
-    promptTemplate: string = ClaudeService.DEFAULT_SUMMARY_PROMPT,
-  ): Promise<{
-    overview?: string;
-    key_points?: { topic: string; summary: string }[];
-    decisions?: string[];
-    actions?: { speaker: string; task: string }[];
-    open_questions?: string[];
-  }> {
-    this.logger.log(`要約開始: model=${model}`);
-
-    const prompt = promptTemplate.replace('{{fullText}}', fullText);
-
-    const response = await this.getClient().messages.create({
-      model,
-      max_tokens: 8192,
-      messages: [{ role: 'user', content: prompt }],
-    });
-
-    const text = response.content[0].type === 'text' ? response.content[0].text : '';
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      this.logger.error(`要約のJSON抽出に失敗。レスポンス: ${text.slice(0, 200)}`);
-      throw new Error('要約結果のパースに失敗しました');
-    }
-
-    let parsed: {
-      overview?: string;
-      key_points?: { topic: string; summary: string }[];
-      decisions?: string[];
-      actions?: { speaker: string; task: string }[];
-      open_questions?: string[];
-    };
-    try {
-      parsed = JSON.parse(jsonMatch[0]);
-    } catch (e) {
-      this.logger.error(`要約JSONのパースに失敗。stop_reason=${response.stop_reason}、レスポンス末尾: ${text.slice(-200)}`);
-      throw new Error('要約結果のパースに失敗しました。音声が長すぎる可能性があります。');
-    }
-
-    this.logger.log('要約完了');
-    return parsed;
-  }
-
   /** 検索結果をまとめて分析 */
   async analyzeSearchResults(
     keywords: string[],
     results: { sourceType: string; sourceName: string; text: string }[],
   ): Promise<string> {
     const resultsText = results
-      .map(
-        (r, i) =>
-          `[${i + 1}] (${r.sourceType}) ${r.sourceName}\n${r.text}`,
-      )
+      .map((r, i) => `[${i + 1}] (${r.sourceType}) ${r.sourceName}\n${r.text}`)
       .join('\n\n');
 
     const prompt = `以下のキーワードに関連する検索結果を分析し、総合的なレポートを作成してください。
@@ -438,7 +283,7 @@ ${resultsText}
 - Markdown形式で構造化して出力してください
 - 重要なポイントを箇条書きでまとめてください`;
 
-    const response = await this.getClient().messages.create({
+    const response = await this.claudeClient.getClient().messages.create({
       model: 'claude-sonnet-4-5-20250929',
       max_tokens: 4096,
       messages: [{ role: 'user', content: prompt }],

--- a/backend/src/claude/claude-client.service.ts
+++ b/backend/src/claude/claude-client.service.ts
@@ -1,0 +1,63 @@
+import { Injectable } from '@nestjs/common';
+import Anthropic from '@anthropic-ai/sdk';
+import axios from 'axios';
+
+/** Anthropicクライアントの生成を担うベースサービス */
+@Injectable()
+export class ClaudeClientService {
+  /**
+   * pkg --jitless 環境では globalThis.fetch が壊れるため、
+   * axios を使った fetch 互換関数を Anthropic クライアントに渡す
+   */
+  private async axiosFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    const method = (init?.method ?? (typeof input !== 'string' && !(input instanceof URL) ? (input as Request).method : undefined) ?? 'GET').toUpperCase();
+
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers;
+      if (h instanceof Headers) {
+        h.forEach((v, k) => { headers[k] = v; });
+      } else if (Array.isArray(h)) {
+        h.forEach(([k, v]) => { headers[k] = v; });
+      } else {
+        Object.assign(headers, h);
+      }
+    }
+
+    const response = await axios({
+      url,
+      method,
+      headers,
+      data: init?.body ?? undefined,
+      responseType: 'arraybuffer',
+      validateStatus: () => true,
+      decompress: true,
+    });
+
+    const bodyBuffer = Buffer.from(response.data as ArrayBuffer);
+    const responseHeaders = new Headers();
+    Object.entries(response.headers).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) {
+        responseHeaders.set(k, String(v));
+      }
+    });
+
+    return new Response(bodyBuffer, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  }
+
+  /** Anthropicクライアントを取得（設定画面からの変更を即時反映） */
+  getClient(): Anthropic {
+    return new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+      fetch: this.axiosFetch.bind(this),
+    });
+  }
+}

--- a/backend/src/claude/claude.module.ts
+++ b/backend/src/claude/claude.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
-import { ClaudeService } from './claude.service';
+import { ClaudeClientService } from './claude-client.service';
+import { AnalysisService } from './analysis.service';
+import { SummaryService } from './summary.service';
 
 /** Claude API共有モジュール */
 @Module({
-  providers: [ClaudeService],
-  exports: [ClaudeService],
+  providers: [ClaudeClientService, AnalysisService, SummaryService],
+  exports: [AnalysisService, SummaryService],
 })
 export class ClaudeModule {}

--- a/backend/src/claude/claude.service.ts
+++ b/backend/src/claude/claude.service.ts
@@ -328,29 +328,42 @@ ${context}
   }
 
   /** 要約プロンプトのデフォルトテンプレート（{{fullText}} を会話全文で置換して使う） */
-  static readonly DEFAULT_SUMMARY_PROMPT = `以下の会話（日本語）を要約してください。
+  static readonly DEFAULT_SUMMARY_PROMPT = `あなたは会議・インタビューの文字起こしを要約するアシスタントです。
 
-## 出力形式
-JSON のみを出力してください。JSON以外は出力しないでください。
+<conversation>
+{{fullText}}
+</conversation>
+
+<instructions>
+上記の会話を分析し、以下のJSON形式のみで出力してください。JSONの前後に説明文やコードブロック記号（\`\`\`）を含めないでください。
+
 {
-  "topics": ["主なトピック1", "主なトピック2"],
-  "conclusion": "会議・会話の結論や合意事項",
-  "actions": ["次のアクション1", "次のアクション2"]
+  "overview": "会話全体の概要を2〜3文で記述",
+  "key_points": [
+    { "topic": "トピック名", "summary": "要点を2〜3文で記述" }
+  ],
+  "decisions": ["決定事項1", "決定事項2"],
+  "actions": [
+    { "speaker": "話者名", "task": "タスク内容を動詞句で記述" }
+  ],
+  "open_questions": ["未解決の質問1", "未解決の質問2"]
 }
 
-## 指示
-- topics: 会話の主なトピックを3〜5点
-- conclusion: 会話全体の結論や合意事項（なければ「特になし」）
-- actions: 次のアクション（なければ空配列）
+- overview: 会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる
+- key_points: 会話で扱われた主なテーマを3〜5点。各トピックの要点を2〜3文で記述する
+- decisions: 会話中に明示的に合意・決定された事項を列挙する。なければ空配列 []
+- actions: 会話中に言及された次のステップを話者名と紐づけて列挙する。話者が不明な場合は「未定」とする。なければ空配列 []
+- open_questions: 結論が出なかった質問・持ち越し事項を列挙する。なければ空配列 []
+</instructions>`;
 
-## 会話全文
-{{fullText}}`;
-
-  /** 要約で選択可能なモデル一覧 */
+  /** 要約で選択可能なモデル一覧（要約向き順） */
   static readonly SUMMARY_MODELS = [
-    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6（推奨）' },
-    { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5（高速・低コスト）' },
-    { id: 'claude-opus-4-7', label: 'Claude Opus 4.7（最高品質）' },
+    { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6（推奨）' },
+    {
+      id: 'claude-haiku-4-5-20251001',
+      label: 'claude-haiku-4-5-20251001（高速・低コスト）',
+    },
+    { id: 'claude-opus-4-7', label: 'claude-opus-4-7（高品質）' },
   ];
 
   /** 会話全文を要約してJSON構造で返す */
@@ -358,29 +371,43 @@ JSON のみを出力してください。JSON以外は出力しないでくだ�
     fullText: string,
     model: string = 'claude-sonnet-4-6',
     promptTemplate: string = ClaudeService.DEFAULT_SUMMARY_PROMPT,
-  ): Promise<{ topics: string[]; conclusion: string; actions: string[] }> {
+  ): Promise<{
+    overview?: string;
+    key_points?: { topic: string; summary: string }[];
+    decisions?: string[];
+    actions?: { speaker: string; task: string }[];
+    open_questions?: string[];
+  }> {
     this.logger.log(`要約開始: model=${model}`);
 
     const prompt = promptTemplate.replace('{{fullText}}', fullText);
 
     const response = await this.getClient().messages.create({
       model,
-      max_tokens: 2048,
+      max_tokens: 8192,
       messages: [{ role: 'user', content: prompt }],
     });
 
     const text = response.content[0].type === 'text' ? response.content[0].text : '';
     const jsonMatch = text.match(/\{[\s\S]*\}/);
     if (!jsonMatch) {
-      this.logger.error('要約のJSON抽出に失敗');
+      this.logger.error(`要約のJSON抽出に失敗。レスポンス: ${text.slice(0, 200)}`);
       throw new Error('要約結果のパースに失敗しました');
     }
 
-    const parsed = JSON.parse(jsonMatch[0]) as {
-      topics: string[];
-      conclusion: string;
-      actions: string[];
+    let parsed: {
+      overview?: string;
+      key_points?: { topic: string; summary: string }[];
+      decisions?: string[];
+      actions?: { speaker: string; task: string }[];
+      open_questions?: string[];
     };
+    try {
+      parsed = JSON.parse(jsonMatch[0]);
+    } catch (e) {
+      this.logger.error(`要約JSONのパースに失敗。stop_reason=${response.stop_reason}、レスポンス末尾: ${text.slice(-200)}`);
+      throw new Error('要約結果のパースに失敗しました。音声が長すぎる可能性があります。');
+    }
 
     this.logger.log('要約完了');
     return parsed;

--- a/backend/src/claude/claude.service.ts
+++ b/backend/src/claude/claude.service.ts
@@ -327,13 +327,8 @@ ${context}
     return { answer, sources };
   }
 
-  /** 会話全文を要約してJSON構造で返す */
-  async summarize(
-    fullText: string,
-  ): Promise<{ topics: string[]; conclusion: string; actions: string[] }> {
-    this.logger.log('要約開始');
-
-    const prompt = `以下の会話（日本語）を要約してください。
+  /** 要約プロンプトのデフォルトテンプレート（{{fullText}} を会話全文で置換して使う） */
+  static readonly DEFAULT_SUMMARY_PROMPT = `以下の会話（日本語）を要約してください。
 
 ## 出力形式
 JSON のみを出力してください。JSON以外は出力しないでください。
@@ -349,10 +344,27 @@ JSON のみを出力してください。JSON以外は出力しないでくだ�
 - actions: 次のアクション（なければ空配列）
 
 ## 会話全文
-${fullText}`;
+{{fullText}}`;
+
+  /** 要約で選択可能なモデル一覧 */
+  static readonly SUMMARY_MODELS = [
+    { id: 'claude-sonnet-4-6', label: 'Claude Sonnet 4.6（推奨）' },
+    { id: 'claude-haiku-4-5-20251001', label: 'Claude Haiku 4.5（高速・低コスト）' },
+    { id: 'claude-opus-4-7', label: 'Claude Opus 4.7（最高品質）' },
+  ];
+
+  /** 会話全文を要約してJSON構造で返す */
+  async summarize(
+    fullText: string,
+    model: string = 'claude-sonnet-4-6',
+    promptTemplate: string = ClaudeService.DEFAULT_SUMMARY_PROMPT,
+  ): Promise<{ topics: string[]; conclusion: string; actions: string[] }> {
+    this.logger.log(`要約開始: model=${model}`);
+
+    const prompt = promptTemplate.replace('{{fullText}}', fullText);
 
     const response = await this.getClient().messages.create({
-      model: 'claude-sonnet-4-5-20250929',
+      model,
       max_tokens: 2048,
       messages: [{ role: 'user', content: prompt }],
     });

--- a/backend/src/claude/claude.service.ts
+++ b/backend/src/claude/claude.service.ts
@@ -327,6 +327,53 @@ ${context}
     return { answer, sources };
   }
 
+  /** 会話全文を要約してJSON構造で返す */
+  async summarize(
+    fullText: string,
+  ): Promise<{ topics: string[]; conclusion: string; actions: string[] }> {
+    this.logger.log('要約開始');
+
+    const prompt = `以下の会話（日本語）を要約してください。
+
+## 出力形式
+JSON のみを出力してください。JSON以外は出力しないでください。
+{
+  "topics": ["主なトピック1", "主なトピック2"],
+  "conclusion": "会議・会話の結論や合意事項",
+  "actions": ["次のアクション1", "次のアクション2"]
+}
+
+## 指示
+- topics: 会話の主なトピックを3〜5点
+- conclusion: 会話全体の結論や合意事項（なければ「特になし」）
+- actions: 次のアクション（なければ空配列）
+
+## 会話全文
+${fullText}`;
+
+    const response = await this.getClient().messages.create({
+      model: 'claude-sonnet-4-5-20250929',
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0].type === 'text' ? response.content[0].text : '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      this.logger.error('要約のJSON抽出に失敗');
+      throw new Error('要約結果のパースに失敗しました');
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as {
+      topics: string[];
+      conclusion: string;
+      actions: string[];
+    };
+
+    this.logger.log('要約完了');
+    return parsed;
+  }
+
   /** 検索結果をまとめて分析 */
   async analyzeSearchResults(
     keywords: string[],

--- a/backend/src/claude/claude.service.ts
+++ b/backend/src/claude/claude.service.ts
@@ -3,55 +3,6 @@ import Anthropic from '@anthropic-ai/sdk';
 import axios from 'axios';
 import { AnalysisResult } from '../interview/types/interview.types';
 
-/**
- * pkg --jitless 環境では globalThis.fetch が壊れるため、
- * axios を使った fetch 互換関数を Anthropic クライアントに渡す
- */
-async function axiosFetch(
-  input: RequestInfo | URL,
-  init?: RequestInit,
-): Promise<Response> {
-  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
-  const method = (init?.method ?? (typeof input !== 'string' && !(input instanceof URL) ? (input as Request).method : undefined) ?? 'GET').toUpperCase();
-
-  // ヘッダーをプレーンオブジェクトに変換
-  const headers: Record<string, string> = {};
-  if (init?.headers) {
-    const h = init.headers;
-    if (h instanceof Headers) {
-      h.forEach((v, k) => { headers[k] = v; });
-    } else if (Array.isArray(h)) {
-      h.forEach(([k, v]) => { headers[k] = v; });
-    } else {
-      Object.assign(headers, h);
-    }
-  }
-
-  const response = await axios({
-    url,
-    method,
-    headers,
-    data: init?.body ?? undefined,
-    responseType: 'arraybuffer',
-    validateStatus: () => true,
-    decompress: true,
-  });
-
-  const bodyBuffer = Buffer.from(response.data as ArrayBuffer);
-  const responseHeaders = new Headers();
-  Object.entries(response.headers).forEach(([k, v]) => {
-    if (v !== undefined && v !== null) {
-      responseHeaders.set(k, String(v));
-    }
-  });
-
-  return new Response(bodyBuffer, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: responseHeaders,
-  });
-}
-
 /** Claude API連携サービス */
 @Injectable()
 export class ClaudeService {
@@ -59,11 +10,59 @@ export class ClaudeService {
 
   constructor() {}
 
+  /**
+   * pkg --jitless 環境では globalThis.fetch が壊れるため、
+   * axios を使った fetch 互換関数を Anthropic クライアントに渡す
+   */
+  private async axiosFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+    const method = (init?.method ?? (typeof input !== 'string' && !(input instanceof URL) ? (input as Request).method : undefined) ?? 'GET').toUpperCase();
+
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      const h = init.headers;
+      if (h instanceof Headers) {
+        h.forEach((v, k) => { headers[k] = v; });
+      } else if (Array.isArray(h)) {
+        h.forEach(([k, v]) => { headers[k] = v; });
+      } else {
+        Object.assign(headers, h);
+      }
+    }
+
+    const response = await axios({
+      url,
+      method,
+      headers,
+      data: init?.body ?? undefined,
+      responseType: 'arraybuffer',
+      validateStatus: () => true,
+      decompress: true,
+    });
+
+    const bodyBuffer = Buffer.from(response.data as ArrayBuffer);
+    const responseHeaders = new Headers();
+    Object.entries(response.headers).forEach(([k, v]) => {
+      if (v !== undefined && v !== null) {
+        responseHeaders.set(k, String(v));
+      }
+    });
+
+    return new Response(bodyBuffer, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: responseHeaders,
+    });
+  }
+
   /** Anthropicクライアントを取得（設定画面からの変更を即時反映） */
   private getClient(): Anthropic {
     return new Anthropic({
       apiKey: process.env.ANTHROPIC_API_KEY,
-      fetch: axiosFetch,
+      fetch: this.axiosFetch.bind(this),
     });
   }
 

--- a/backend/src/claude/summary.service.spec.ts
+++ b/backend/src/claude/summary.service.spec.ts
@@ -1,0 +1,90 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SummaryService } from './summary.service';
+import { ClaudeClientService } from './claude-client.service';
+
+/** Anthropic messages.create のモック */
+const mockMessagesCreate = jest.fn();
+const mockClaudeClientService = {
+  getClient: () => ({
+    messages: {
+      create: mockMessagesCreate,
+    },
+  }),
+};
+
+/** 正常なJSONレスポンスを返すヘルパー */
+function makeResponse(json: object) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(json) }],
+    stop_reason: 'end_turn',
+  };
+}
+
+describe('SummaryService', () => {
+  let service: SummaryService;
+
+  beforeEach(async () => {
+    mockMessagesCreate.mockReset();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SummaryService,
+        { provide: ClaudeClientService, useValue: mockClaudeClientService },
+      ],
+    }).compile();
+
+    service = module.get<SummaryService>(SummaryService);
+  });
+
+  describe('summarize', () => {
+    it('Claudeから正常なJSONが返ったときパースして返す', async () => {
+      mockMessagesCreate.mockResolvedValue(
+        makeResponse({
+          overview: '概要',
+          key_points: [{ topic: 'テーマ', summary: '要点' }],
+          decisions: ['決定1'],
+        }),
+      );
+
+      const result = await service.summarize('会話テキスト');
+
+      expect(result.overview).toBe('概要');
+      expect(result.key_points).toEqual([{ topic: 'テーマ', summary: '要点' }]);
+      expect(result.decisions).toEqual(['決定1']);
+    });
+
+    it('レスポンスにJSONが含まれないとき要約パースエラーをスロー', async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [{ type: 'text', text: 'JSONなし。テキストのみ。' }],
+        stop_reason: 'end_turn',
+      });
+
+      await expect(service.summarize('会話テキスト')).rejects.toThrow(
+        '要約結果のパースに失敗しました',
+      );
+    });
+
+    it('JSONが壊れているときパースエラーをスロー', async () => {
+      mockMessagesCreate.mockResolvedValue({
+        content: [{ type: 'text', text: '{ "overview": "未完了の' }],
+        stop_reason: 'max_tokens',
+      });
+
+      await expect(service.summarize('会話テキスト')).rejects.toThrow(
+        '要約結果のパースに失敗しました',
+      );
+    });
+
+    it('{{fullText}} が会話全文に置換されてClaudeに渡される', async () => {
+      mockMessagesCreate.mockResolvedValue(makeResponse({ overview: '概要', key_points: [], decisions: [] }));
+
+      await service.summarize('実際の会話内容', 'claude-sonnet-4-6', '要約してください: {{fullText}}');
+
+      expect(mockMessagesCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [{ role: 'user', content: '要約してください: 実際の会話内容' }],
+        }),
+      );
+    });
+  });
+});

--- a/backend/src/claude/summary.service.ts
+++ b/backend/src/claude/summary.service.ts
@@ -21,18 +21,12 @@ export class SummaryService {
   "key_points": [
     { "topic": "トピック名", "summary": "要点を2〜3文で記述" }
   ],
-  "decisions": ["決定事項1", "決定事項2"],
-  "actions": [
-    { "speaker": "話者名", "task": "タスク内容を動詞句で記述" }
-  ],
-  "open_questions": ["未解決の質問1", "未解決の質問2"]
+  "decisions": ["決定事項1", "決定事項2"]
 }
 
 - overview: 会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる
 - key_points: 会話で扱われた主なテーマを3〜5点。各トピックの要点を2〜3文で記述する
 - decisions: 会話中に明示的に合意・決定された事項を列挙する。なければ空配列 []
-- actions: 会話中に言及された次のステップを話者名と紐づけて列挙する。話者が不明な場合は「未定」とする。なければ空配列 []
-- open_questions: 結論が出なかった質問・持ち越し事項を列挙する。なければ空配列 []
 </instructions>`;
 
   /** 要約で選択可能なモデル一覧（要約向き順） */
@@ -56,8 +50,6 @@ export class SummaryService {
     overview?: string;
     key_points?: { topic: string; summary: string }[];
     decisions?: string[];
-    actions?: { speaker: string; task: string }[];
-    open_questions?: string[];
   }> {
     this.logger.log(`要約開始: model=${model}`);
 
@@ -80,8 +72,6 @@ export class SummaryService {
       overview?: string;
       key_points?: { topic: string; summary: string }[];
       decisions?: string[];
-      actions?: { speaker: string; task: string }[];
-      open_questions?: string[];
     };
     try {
       parsed = JSON.parse(jsonMatch[0]);

--- a/backend/src/claude/summary.service.ts
+++ b/backend/src/claude/summary.service.ts
@@ -1,0 +1,96 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ClaudeClientService } from './claude-client.service';
+
+/** 会話要約を担うサービス */
+@Injectable()
+export class SummaryService {
+  private readonly logger = new Logger(SummaryService.name);
+
+  /** 要約プロンプトのデフォルトテンプレート（{{fullText}} を会話全文で置換して使う） */
+  static readonly DEFAULT_SUMMARY_PROMPT = `あなたは会議・インタビューの文字起こしを要約するアシスタントです。
+
+<conversation>
+{{fullText}}
+</conversation>
+
+<instructions>
+上記の会話を分析し、以下のJSON形式のみで出力してください。JSONの前後に説明文やコードブロック記号（\`\`\`）を含めないでください。
+
+{
+  "overview": "会話全体の概要を2〜3文で記述",
+  "key_points": [
+    { "topic": "トピック名", "summary": "要点を2〜3文で記述" }
+  ],
+  "decisions": ["決定事項1", "決定事項2"],
+  "actions": [
+    { "speaker": "話者名", "task": "タスク内容を動詞句で記述" }
+  ],
+  "open_questions": ["未解決の質問1", "未解決の質問2"]
+}
+
+- overview: 会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる
+- key_points: 会話で扱われた主なテーマを3〜5点。各トピックの要点を2〜3文で記述する
+- decisions: 会話中に明示的に合意・決定された事項を列挙する。なければ空配列 []
+- actions: 会話中に言及された次のステップを話者名と紐づけて列挙する。話者が不明な場合は「未定」とする。なければ空配列 []
+- open_questions: 結論が出なかった質問・持ち越し事項を列挙する。なければ空配列 []
+</instructions>`;
+
+  /** 要約で選択可能なモデル一覧（要約向き順） */
+  static readonly SUMMARY_MODELS = [
+    { id: 'claude-sonnet-4-6', label: 'claude-sonnet-4-6（推奨）' },
+    {
+      id: 'claude-haiku-4-5-20251001',
+      label: 'claude-haiku-4-5-20251001（高速・低コスト）',
+    },
+    { id: 'claude-opus-4-7', label: 'claude-opus-4-7（高品質）' },
+  ];
+
+  constructor(private readonly claudeClient: ClaudeClientService) {}
+
+  /** 会話全文を要約してJSON構造で返す */
+  async summarize(
+    fullText: string,
+    model: string = 'claude-sonnet-4-6',
+    promptTemplate: string = SummaryService.DEFAULT_SUMMARY_PROMPT,
+  ): Promise<{
+    overview?: string;
+    key_points?: { topic: string; summary: string }[];
+    decisions?: string[];
+    actions?: { speaker: string; task: string }[];
+    open_questions?: string[];
+  }> {
+    this.logger.log(`要約開始: model=${model}`);
+
+    const prompt = promptTemplate.replace('{{fullText}}', fullText);
+
+    const response = await this.claudeClient.getClient().messages.create({
+      model,
+      max_tokens: 8192,
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    const text = response.content[0].type === 'text' ? response.content[0].text : '';
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      this.logger.error(`要約のJSON抽出に失敗。レスポンス: ${text.slice(0, 200)}`);
+      throw new Error('要約結果のパースに失敗しました');
+    }
+
+    let parsed: {
+      overview?: string;
+      key_points?: { topic: string; summary: string }[];
+      decisions?: string[];
+      actions?: { speaker: string; task: string }[];
+      open_questions?: string[];
+    };
+    try {
+      parsed = JSON.parse(jsonMatch[0]);
+    } catch (e) {
+      this.logger.error(`要約JSONのパースに失敗。stop_reason=${response.stop_reason}、レスポンス末尾: ${text.slice(-200)}`);
+      throw new Error('要約結果のパースに失敗しました。音声が長すぎる可能性があります。');
+    }
+
+    this.logger.log('要約完了');
+    return parsed;
+  }
+}

--- a/backend/src/deep-search/deep-search.service.spec.ts
+++ b/backend/src/deep-search/deep-search.service.spec.ts
@@ -3,7 +3,7 @@ import { DeepSearchService } from './deep-search.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
 import { EmbeddingService } from '../document/embedding.service';
 import { VectorSearchService } from '../document/vector-search.service';
-import { ClaudeService } from '../claude/claude.service';
+import { AnalysisService } from '../claude/analysis.service';
 import { DeepSearchDto, DeepSearchAnalyzeDto } from './dto/deep-search.dto';
 
 /** テスト用の文字起こしデータ */
@@ -40,7 +40,7 @@ describe('DeepSearchService', () => {
   let transcriptionStore: jest.Mocked<TranscriptionStoreService>;
   let embeddingService: jest.Mocked<EmbeddingService>;
   let vectorSearchService: jest.Mocked<VectorSearchService>;
-  let claudeService: jest.Mocked<ClaudeService>;
+  let claudeService: jest.Mocked<AnalysisService>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -65,7 +65,7 @@ describe('DeepSearchService', () => {
           },
         },
         {
-          provide: ClaudeService,
+          provide: AnalysisService,
           useValue: {
             searchAndAnalyze: jest.fn(),
             analyzeSearchResults: jest.fn(),
@@ -78,7 +78,7 @@ describe('DeepSearchService', () => {
     transcriptionStore = module.get(TranscriptionStoreService);
     embeddingService = module.get(EmbeddingService);
     vectorSearchService = module.get(VectorSearchService);
-    claudeService = module.get(ClaudeService);
+    claudeService = module.get(AnalysisService);
   });
 
   describe('search', () => {

--- a/backend/src/deep-search/deep-search.service.ts
+++ b/backend/src/deep-search/deep-search.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
 import { EmbeddingService } from '../document/embedding.service';
 import { VectorSearchService } from '../document/vector-search.service';
-import { ClaudeService } from '../claude/claude.service';
+import { AnalysisService } from '../claude/analysis.service';
 import { DeepSearchDto, DeepSearchAnalyzeDto } from './dto/deep-search.dto';
 import {
   DeepSearchResponse,
@@ -19,7 +19,7 @@ export class DeepSearchService {
     private readonly transcriptionStore: TranscriptionStoreService,
     private readonly embeddingService: EmbeddingService,
     private readonly vectorSearchService: VectorSearchService,
-    private readonly claudeService: ClaudeService,
+    private readonly analysisService: AnalysisService,
   ) {}
 
   /** ディープサーチ実行（3ソース横断） */
@@ -61,7 +61,7 @@ export class DeepSearchService {
       `ディープサーチ分析開始: ${dto.results.length}件の結果を分析`,
     );
 
-    const analysis = await this.claudeService.analyzeSearchResults(
+    const analysis = await this.analysisService.analyzeSearchResults(
       dto.keywords,
       dto.results,
     );
@@ -142,7 +142,7 @@ export class DeepSearchService {
   ): Promise<DeepSearchResultItem[]> {
     try {
       const queryText = keywords.join(' ');
-      const { answer, sources } = await this.claudeService.searchAndAnalyze(
+      const { answer, sources } = await this.analysisService.searchAndAnalyze(
         keywords,
         `キーワード「${queryText}」に関連する最新情報を調査してください。`,
       );

--- a/backend/src/interview/analysis-log.storage.ts
+++ b/backend/src/interview/analysis-log.storage.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { existsSync, mkdirSync } from 'fs';
-import { InterviewAnalysis } from './types/interview.types';
+import { InterviewAnalysis, TranscriptionSummaryLog } from './types/interview.types';
 
 /** 会話分析ログをローカルファイルに保存・取得するサービス */
 @Injectable()
@@ -75,5 +75,59 @@ export class AnalysisLogStorage {
 
     this.logger.log(`分析ログ一覧取得完了: ${summaries.length}件`);
     return summaries;
+  }
+}
+
+/** 要約ログをローカルファイルに保存・取得するサービス */
+@Injectable()
+export class SummaryLogStorage {
+  private readonly logger = new Logger(SummaryLogStorage.name);
+  private readonly storeDir: string;
+
+  constructor(private readonly configService: ConfigService) {
+    const dataDir = this.configService.get<string>('DATA_DIR') || './data';
+    this.storeDir = path.resolve(path.join(dataDir, 'summary-logs'));
+
+    if (!existsSync(this.storeDir)) {
+      mkdirSync(this.storeDir, { recursive: true });
+    }
+    this.logger.log(`要約ログ保存ディレクトリ: ${this.storeDir}`);
+  }
+
+  private getFilePath(id: string): string {
+    return path.join(this.storeDir, `${id}.json`);
+  }
+
+  async save(summary: TranscriptionSummaryLog): Promise<void> {
+    await fs.writeFile(this.getFilePath(summary.id), JSON.stringify(summary, null, 2), 'utf-8');
+    this.logger.log(`要約ログ保存完了: ${summary.id}`);
+  }
+
+  async findById(id: string): Promise<TranscriptionSummaryLog | null> {
+    const filePath = this.getFilePath(id);
+    if (!existsSync(filePath)) return null;
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content) as TranscriptionSummaryLog;
+  }
+
+  async findAll(): Promise<TranscriptionSummaryLog[]> {
+    if (!existsSync(this.storeDir)) return [];
+
+    const entries = await fs.readdir(this.storeDir, { withFileTypes: true });
+    const logs: TranscriptionSummaryLog[] = [];
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+      try {
+        const content = await fs.readFile(path.join(this.storeDir, entry.name), 'utf-8');
+        logs.push(JSON.parse(content) as TranscriptionSummaryLog);
+      } catch (error) {
+        this.logger.warn(`要約ログの読み込みに失敗: ${entry.name}`, error);
+      }
+    }
+
+    logs.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    this.logger.log(`要約ログ一覧取得完了: ${logs.length}件`);
+    return logs;
   }
 }

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -67,4 +67,25 @@ export class InterviewController {
     const log = await this.interviewService.findAnalysisLogById(id);
     return { log };
   }
+
+  /** 要約生成: POST /api/interview/summarize */
+  @Post('summarize')
+  async summarize(@Body() body: { transcriptionId: string }) {
+    const summary = await this.interviewService.summarize(body.transcriptionId);
+    return { summary };
+  }
+
+  /** 要約ログ一覧: GET /api/interview/summary-logs */
+  @Get('summary-logs')
+  async findSummaryLogs() {
+    const logs = await this.interviewService.findSummaryLogs();
+    return { logs };
+  }
+
+  /** 要約ログ詳細: GET /api/interview/summary-logs/:id */
+  @Get('summary-logs/:id')
+  async findSummaryLogById(@Param('id') id: string) {
+    const log = await this.interviewService.findSummaryLogById(id);
+    return { log };
+  }
 }

--- a/backend/src/interview/interview.controller.ts
+++ b/backend/src/interview/interview.controller.ts
@@ -68,10 +68,20 @@ export class InterviewController {
     return { log };
   }
 
+  /** 要約設定（デフォルトプロンプト・モデル一覧）取得: GET /api/interview/summary-config */
+  @Get('summary-config')
+  getSummaryConfig() {
+    return this.interviewService.getSummaryConfig();
+  }
+
   /** 要約生成: POST /api/interview/summarize */
   @Post('summarize')
-  async summarize(@Body() body: { transcriptionId: string }) {
-    const summary = await this.interviewService.summarize(body.transcriptionId);
+  async summarize(@Body() body: { transcriptionId: string; model: string; prompt: string }) {
+    const summary = await this.interviewService.summarize(
+      body.transcriptionId,
+      body.model,
+      body.prompt,
+    );
     return { summary };
   }
 

--- a/backend/src/interview/interview.module.ts
+++ b/backend/src/interview/interview.module.ts
@@ -3,11 +3,11 @@ import { TranscriptionModule } from '../transcription/transcription.module';
 import { ClaudeModule } from '../claude/claude.module';
 import { InterviewController } from './interview.controller';
 import { InterviewService } from './interview.service';
-import { AnalysisLogStorage } from './analysis-log.storage';
+import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 
 @Module({
   imports: [TranscriptionModule, ClaudeModule],
   controllers: [InterviewController],
-  providers: [InterviewService, AnalysisLogStorage],
+  providers: [InterviewService, AnalysisLogStorage, SummaryLogStorage],
 })
 export class InterviewModule {}

--- a/backend/src/interview/interview.service.spec.ts
+++ b/backend/src/interview/interview.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { InterviewService } from './interview.service';
 import { AnalysisService } from '../claude/analysis.service';
+import { SummaryService } from '../claude/summary.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
 import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 
@@ -55,6 +56,12 @@ describe('InterviewService', () => {
             buildAnalysisPrompt: jest.fn(),
             analyze: jest.fn(),
             analyzeContext: jest.fn(),
+          },
+        },
+        {
+          provide: SummaryService,
+          useValue: {
+            summarize: jest.fn(),
           },
         },
         {

--- a/backend/src/interview/interview.service.spec.ts
+++ b/backend/src/interview/interview.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { NotFoundException } from '@nestjs/common';
 import { InterviewService } from './interview.service';
-import { ClaudeService } from '../claude/claude.service';
+import { AnalysisService } from '../claude/analysis.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
 import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 
@@ -39,7 +39,7 @@ const sampleTranscription = {
 
 describe('InterviewService', () => {
   let service: InterviewService;
-  let claudeService: jest.Mocked<ClaudeService>;
+  let claudeService: jest.Mocked<AnalysisService>;
   let store: jest.Mocked<TranscriptionStoreService>;
   let analysisLogStorage: jest.Mocked<AnalysisLogStorage>;
 
@@ -48,7 +48,7 @@ describe('InterviewService', () => {
       providers: [
         InterviewService,
         {
-          provide: ClaudeService,
+          provide: AnalysisService,
           useValue: {
             generateQuestions: jest.fn(),
             buildGenerateQuestionsPrompt: jest.fn(),
@@ -83,7 +83,7 @@ describe('InterviewService', () => {
     }).compile();
 
     service = module.get<InterviewService>(InterviewService);
-    claudeService = module.get(ClaudeService);
+    claudeService = module.get(AnalysisService);
     store = module.get(TranscriptionStoreService);
     analysisLogStorage = module.get(AnalysisLogStorage);
   });

--- a/backend/src/interview/interview.service.spec.ts
+++ b/backend/src/interview/interview.service.spec.ts
@@ -39,13 +39,14 @@ const sampleTranscription = {
 };
 
 describe('InterviewService', () => {
+  let module: TestingModule;
   let service: InterviewService;
   let claudeService: jest.Mocked<AnalysisService>;
   let store: jest.Mocked<TranscriptionStoreService>;
   let analysisLogStorage: jest.Mocked<AnalysisLogStorage>;
 
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    module = await Test.createTestingModule({
       providers: [
         InterviewService,
         {
@@ -186,6 +187,51 @@ describe('InterviewService', () => {
       analysisLogStorage.findById.mockResolvedValue(null);
 
       await expect(service.findAnalysisLogById('missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('getSummaryConfig', () => {
+    it('デフォルトプロンプトとモデル一覧を返す', () => {
+      const config = service.getSummaryConfig();
+
+      expect(config.defaultPrompt).toBe(SummaryService.DEFAULT_SUMMARY_PROMPT);
+      expect(config.models).toEqual(SummaryService.SUMMARY_MODELS);
+      expect(config.models.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('summarize', () => {
+    it('SummaryServiceを呼び出してログを保存し結果を返す', async () => {
+      const summaryService = module.get<jest.Mocked<SummaryService>>(SummaryService);
+      const summaryLogStorage = module.get<jest.Mocked<SummaryLogStorage>>(SummaryLogStorage);
+      store.findById.mockResolvedValue(sampleTranscription);
+      summaryService.summarize.mockResolvedValue({
+        overview: '会話の概要',
+        key_points: [{ topic: 'テーマ1', summary: '要点1' }],
+        decisions: ['決定事項1'],
+      });
+      summaryLogStorage.save.mockResolvedValue(undefined);
+
+      const result = await service.summarize('sample', 'claude-sonnet-4-6', 'プロンプト {{fullText}}');
+
+      expect(summaryService.summarize).toHaveBeenCalledWith(
+        sampleTranscription.fullText,
+        'claude-sonnet-4-6',
+        'プロンプト {{fullText}}',
+      );
+      expect(summaryLogStorage.save).toHaveBeenCalledWith(result);
+      expect(result.transcriptionId).toBe('sample');
+      expect(result.overview).toBe('会話の概要');
+      expect(result.model).toBe('claude-sonnet-4-6');
+    });
+  });
+
+  describe('findSummaryLogById', () => {
+    it('存在しない要約ログIDはNotFoundExceptionをスロー', async () => {
+      const summaryLogStorage = module.get<jest.Mocked<SummaryLogStorage>>(SummaryLogStorage);
+      summaryLogStorage.findById.mockResolvedValue(null);
+
+      await expect(service.findSummaryLogById('missing')).rejects.toThrow(NotFoundException);
     });
   });
 

--- a/backend/src/interview/interview.service.spec.ts
+++ b/backend/src/interview/interview.service.spec.ts
@@ -3,7 +3,7 @@ import { NotFoundException } from '@nestjs/common';
 import { InterviewService } from './interview.service';
 import { ClaudeService } from '../claude/claude.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
-import { AnalysisLogStorage } from './analysis-log.storage';
+import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 
 /** テスト用の文字起こしデータ */
 const sampleTranscription = {
@@ -69,6 +69,14 @@ describe('InterviewService', () => {
             save: jest.fn(),
             findById: jest.fn(),
             findAllSummaries: jest.fn(),
+          },
+        },
+        {
+          provide: SummaryLogStorage,
+          useValue: {
+            save: jest.fn(),
+            findById: jest.fn(),
+            findAll: jest.fn(),
           },
         },
       ],

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -2,9 +2,10 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
 import { ClaudeService } from '../claude/claude.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
-import { AnalysisLogStorage } from './analysis-log.storage';
+import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 import {
   InterviewAnalysis,
+  TranscriptionSummaryLog,
   UtteranceContextResult,
   ContextAnalysisResponse,
 } from './types/interview.types';
@@ -18,6 +19,7 @@ export class InterviewService {
     private readonly claudeService: ClaudeService,
     private readonly store: TranscriptionStoreService,
     private readonly analysisLogStorage: AnalysisLogStorage,
+    private readonly summaryLogStorage: SummaryLogStorage,
   ) {}
 
   /** 話者名を取得するヘルパー */
@@ -119,6 +121,43 @@ export class InterviewService {
     const log = await this.analysisLogStorage.findById(id);
     if (!log) {
       throw new NotFoundException(`分析ログが見つかりません: ${id}`);
+    }
+    return log;
+  }
+
+  /** 要約を生成して保存 */
+  async summarize(transcriptionId: string): Promise<TranscriptionSummaryLog> {
+    const transcription = await this.store.findById(transcriptionId);
+    if (!transcription) {
+      throw new NotFoundException(`文字起こし結果が見つかりません: ${transcriptionId}`);
+    }
+
+    this.logger.log(`要約開始: transcriptionId=${transcriptionId}`);
+    const result = await this.claudeService.summarize(transcription.fullText);
+
+    const summary: TranscriptionSummaryLog = {
+      id: uuidv4(),
+      transcriptionId,
+      topics: result.topics,
+      conclusion: result.conclusion,
+      actions: result.actions,
+      createdAt: new Date().toISOString(),
+    };
+
+    await this.summaryLogStorage.save(summary);
+    return summary;
+  }
+
+  /** 要約ログ一覧を取得 */
+  async findSummaryLogs(): Promise<TranscriptionSummaryLog[]> {
+    return this.summaryLogStorage.findAll();
+  }
+
+  /** 要約ログ詳細を取得 */
+  async findSummaryLogById(id: string): Promise<TranscriptionSummaryLog> {
+    const log = await this.summaryLogStorage.findById(id);
+    if (!log) {
+      throw new NotFoundException(`要約ログが見つかりません: ${id}`);
     }
     return log;
   }

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -157,13 +157,16 @@ export class InterviewService {
     const summary: TranscriptionSummaryLog = {
       id: uuidv4(),
       transcriptionId,
-      topics: result.topics,
-      conclusion: result.conclusion,
+      overview: result.overview,
+      key_points: result.key_points,
+      decisions: result.decisions,
       actions: result.actions,
+      open_questions: result.open_questions,
       createdAt: new Date().toISOString(),
       model,
       prompt: promptTemplate,
     };
+
 
     await this.summaryLogStorage.save(summary);
     return summary;

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { v4 as uuidv4 } from 'uuid';
-import { ClaudeService } from '../claude/claude.service';
+import { AnalysisService } from '../claude/analysis.service';
+import { SummaryService } from '../claude/summary.service';
 import { TranscriptionStoreService } from '../transcription/transcription-store.service';
 import { AnalysisLogStorage, SummaryLogStorage } from './analysis-log.storage';
 import {
@@ -16,7 +17,8 @@ export class InterviewService {
   private readonly logger = new Logger(InterviewService.name);
 
   constructor(
-    private readonly claudeService: ClaudeService,
+    private readonly analysisService: AnalysisService,
+    private readonly summaryService: SummaryService,
     private readonly store: TranscriptionStoreService,
     private readonly analysisLogStorage: AnalysisLogStorage,
     private readonly summaryLogStorage: SummaryLogStorage,
@@ -48,7 +50,7 @@ export class InterviewService {
       speakerId,
     );
 
-    return this.claudeService.generateQuestions(keywords, speakerName);
+    return this.analysisService.generateQuestions(keywords, speakerName);
   }
 
   /** プロンプトのプレビューを返す */
@@ -64,10 +66,10 @@ export class InterviewService {
     );
 
     const generateQuestionsPrompt =
-      this.claudeService.buildGenerateQuestionsPrompt(keywords, speakerName);
+      this.analysisService.buildGenerateQuestionsPrompt(keywords, speakerName);
 
     const analyzePrompts = questions.map((q) =>
-      this.claudeService.buildAnalysisPrompt(q, keywords, speakerName),
+      this.analysisService.buildAnalysisPrompt(q, keywords, speakerName),
     );
 
     return { generateQuestionsPrompt, analyzePrompts };
@@ -89,7 +91,7 @@ export class InterviewService {
       `分析開始: ${speakerName}, キーワード=${keywords.length}件, 質問=${questions.length}件`,
     );
 
-    const results = await this.claudeService.analyze(
+    const results = await this.analysisService.analyze(
       questions,
       keywords,
       speakerName,
@@ -131,8 +133,8 @@ export class InterviewService {
     models: { id: string; label: string }[];
   } {
     return {
-      defaultPrompt: ClaudeService.DEFAULT_SUMMARY_PROMPT,
-      models: ClaudeService.SUMMARY_MODELS,
+      defaultPrompt: SummaryService.DEFAULT_SUMMARY_PROMPT,
+      models: SummaryService.SUMMARY_MODELS,
     };
   }
 
@@ -148,7 +150,7 @@ export class InterviewService {
     }
 
     this.logger.log(`要約開始: transcriptionId=${transcriptionId}, model=${model}`);
-    const result = await this.claudeService.summarize(
+    const result = await this.summaryService.summarize(
       transcription.fullText,
       model,
       promptTemplate,
@@ -209,7 +211,7 @@ export class InterviewService {
     }));
 
     // Claude APIで意図・話題を分析
-    const llmResults = await this.claudeService.analyzeContext(
+    const llmResults = await this.analysisService.analyzeContext(
       allUtterances,
       utteranceIndices,
     );

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -125,15 +125,34 @@ export class InterviewService {
     return log;
   }
 
+  /** 要約プロンプトのデフォルトテンプレートと選択可能なモデル一覧を返す */
+  getSummaryConfig(): {
+    defaultPrompt: string;
+    models: { id: string; label: string }[];
+  } {
+    return {
+      defaultPrompt: ClaudeService.DEFAULT_SUMMARY_PROMPT,
+      models: ClaudeService.SUMMARY_MODELS,
+    };
+  }
+
   /** 要約を生成して保存 */
-  async summarize(transcriptionId: string): Promise<TranscriptionSummaryLog> {
+  async summarize(
+    transcriptionId: string,
+    model: string,
+    promptTemplate: string,
+  ): Promise<TranscriptionSummaryLog> {
     const transcription = await this.store.findById(transcriptionId);
     if (!transcription) {
       throw new NotFoundException(`文字起こし結果が見つかりません: ${transcriptionId}`);
     }
 
-    this.logger.log(`要約開始: transcriptionId=${transcriptionId}`);
-    const result = await this.claudeService.summarize(transcription.fullText);
+    this.logger.log(`要約開始: transcriptionId=${transcriptionId}, model=${model}`);
+    const result = await this.claudeService.summarize(
+      transcription.fullText,
+      model,
+      promptTemplate,
+    );
 
     const summary: TranscriptionSummaryLog = {
       id: uuidv4(),
@@ -142,6 +161,8 @@ export class InterviewService {
       conclusion: result.conclusion,
       actions: result.actions,
       createdAt: new Date().toISOString(),
+      model,
+      prompt: promptTemplate,
     };
 
     await this.summaryLogStorage.save(summary);

--- a/backend/src/interview/interview.service.ts
+++ b/backend/src/interview/interview.service.ts
@@ -162,8 +162,6 @@ export class InterviewService {
       overview: result.overview,
       key_points: result.key_points,
       decisions: result.decisions,
-      actions: result.actions,
-      open_questions: result.open_questions,
       createdAt: new Date().toISOString(),
       model,
       prompt: promptTemplate,

--- a/backend/src/interview/types/interview.types.ts
+++ b/backend/src/interview/types/interview.types.ts
@@ -55,14 +55,6 @@ export interface ContextAnalysisResponse {
   results: UtteranceContextResult[];
 }
 
-/** 要約のアクションアイテム */
-export interface SummaryActionItem {
-  /** 担当話者名 */
-  speaker: string;
-  /** タスク内容 */
-  task: string;
-}
-
 /** 要約のキーポイント */
 export interface SummaryKeyPoint {
   /** トピック名 */
@@ -83,10 +75,6 @@ export interface TranscriptionSummaryLog {
   key_points?: SummaryKeyPoint[];
   /** 決定事項。プロンプトで除外された場合は undefined */
   decisions?: string[];
-  /** 次のアクション（話者紐づき）。プロンプトで除外された場合は undefined */
-  actions?: SummaryActionItem[];
-  /** 未解決の質問・宿題。プロンプトで除外された場合は undefined */
-  open_questions?: string[];
   /** 作成日時（ISO 8601） */
   createdAt: string;
   /** 使用したモデルID */

--- a/backend/src/interview/types/interview.types.ts
+++ b/backend/src/interview/types/interview.types.ts
@@ -54,3 +54,19 @@ export interface ContextAnalysisResponse {
   /** 分析結果 */
   results: UtteranceContextResult[];
 }
+
+/** 要約結果 */
+export interface TranscriptionSummaryLog {
+  /** 一意のID */
+  id: string;
+  /** 文字起こしID */
+  transcriptionId: string;
+  /** 主なトピック */
+  topics: string[];
+  /** 結論・合意事項 */
+  conclusion: string;
+  /** 次のアクション（なければ空配列） */
+  actions: string[];
+  /** 作成日時（ISO 8601） */
+  createdAt: string;
+}

--- a/backend/src/interview/types/interview.types.ts
+++ b/backend/src/interview/types/interview.types.ts
@@ -55,18 +55,38 @@ export interface ContextAnalysisResponse {
   results: UtteranceContextResult[];
 }
 
+/** 要約のアクションアイテム */
+export interface SummaryActionItem {
+  /** 担当話者名 */
+  speaker: string;
+  /** タスク内容 */
+  task: string;
+}
+
+/** 要約のキーポイント */
+export interface SummaryKeyPoint {
+  /** トピック名 */
+  topic: string;
+  /** 要点（2〜3文） */
+  summary: string;
+}
+
 /** 要約結果 */
 export interface TranscriptionSummaryLog {
   /** 一意のID */
   id: string;
   /** 文字起こしID */
   transcriptionId: string;
-  /** 主なトピック */
-  topics: string[];
-  /** 結論・合意事項 */
-  conclusion: string;
-  /** 次のアクション（なければ空配列） */
-  actions: string[];
+  /** 会話全体の概要（2〜3文）。プロンプトで除外された場合は undefined */
+  overview?: string;
+  /** キーポイント（トピック＋要点のペア）。プロンプトで除外された場合は undefined */
+  key_points?: SummaryKeyPoint[];
+  /** 決定事項。プロンプトで除外された場合は undefined */
+  decisions?: string[];
+  /** 次のアクション（話者紐づき）。プロンプトで除外された場合は undefined */
+  actions?: SummaryActionItem[];
+  /** 未解決の質問・宿題。プロンプトで除外された場合は undefined */
+  open_questions?: string[];
   /** 作成日時（ISO 8601） */
   createdAt: string;
   /** 使用したモデルID */

--- a/backend/src/interview/types/interview.types.ts
+++ b/backend/src/interview/types/interview.types.ts
@@ -69,4 +69,8 @@ export interface TranscriptionSummaryLog {
   actions: string[];
   /** 作成日時（ISO 8601） */
   createdAt: string;
+  /** 使用したモデルID */
+  model: string;
+  /** 実際に使用したプロンプト */
+  prompt: string;
 }

--- a/backend/src/settings/settings.service.ts
+++ b/backend/src/settings/settings.service.ts
@@ -22,6 +22,7 @@ export interface AppSettings {
     transcriptionsDir: string;
     documentsDir: string;
     documentMetadataDir: string;
+    summaryLogsDir: string;
   };
   apiKeys: {
     elevenlabsApiKey: string;
@@ -70,6 +71,7 @@ export class SettingsService {
           this.configService.get<string>('DOCUMENT_METADATA_DIR') ||
             path.join(dataDir, 'document-metadata'),
         ),
+        summaryLogsDir: path.resolve(path.join(dataDir, 'summary-logs')),
       },
       apiKeys: {
         elevenlabsApiKey:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { SpeakerNameEditor } from './components/SpeakerNameEditor';
 import { AudioPlayer } from './components/AudioPlayer';
 import { KeywordList } from './components/KeywordList';
 import { InterviewPage } from './components/InterviewPage';
+import { SummaryPage } from './components/SummaryPage';
 import { DeepSearchPage } from './components/DeepSearchPage';
 import { TranscribePage } from './components/TranscribePage';
 import { JobProgressPage } from './components/JobProgressPage';
@@ -22,7 +23,7 @@ import { extractKeywords } from './utils/keywords';
 import type { Transcription, ContextAnalysisResponse } from './types';
 import './App.css';
 
-type Page = 'main' | 'transcribe' | 'interview' | 'deep-search' | 'settings' | 'job-progress' | 'resumable-jobs';
+type Page = 'main' | 'transcribe' | 'summary' | 'interview' | 'deep-search' | 'settings' | 'job-progress' | 'resumable-jobs';
 
 function App() {
   const [transcription, setTranscription] = useState<Transcription | null>(
@@ -181,6 +182,16 @@ function App() {
       setLoading(false);
     }
   };
+
+  /** 要約ページの場合 */
+  if (page === 'summary' && transcription) {
+    return (
+      <SummaryPage
+        transcriptionId={transcription.id}
+        onBack={() => setPage('main')}
+      />
+    );
+  }
 
   /** 会話分析ページの場合 */
   if (page === 'interview' && transcription) {
@@ -397,6 +408,7 @@ function App() {
               onToggleKeyword={toggleKeywordHighlight}
               filterActive={filterActive}
               onToggleFilter={() => setFilterActive((prev) => !prev)}
+              onNavigateSummary={() => setPage('summary')}
               onNavigateInterview={() => setPage('interview')}
               onNavigateDeepSearch={enableDeepSearch ? () => setPage('deep-search') : undefined}
               onToggleContextMode={enableContextAnalysis ? toggleContextMode : undefined}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,6 +10,7 @@ import type {
   Transcription,
   TranscriptionSummary,
   TranscriptionSummaryLog,
+  SummaryConfig,
 } from '../types';
 
 /**
@@ -736,14 +737,25 @@ export async function transcribePodcastFile(
 
 // === 要約 ===
 
+/** 要約設定（デフォルトプロンプト・モデル一覧）を取得 */
+export async function fetchSummaryConfig(): Promise<SummaryConfig> {
+  const res = await fetch(`${BASE_URL}/interview/summary-config`);
+  if (!res.ok) {
+    throw new Error(`要約設定の取得に失敗しました: ${res.status}`);
+  }
+  return res.json();
+}
+
 /** 要約を生成 */
 export async function summarizeTranscription(
   transcriptionId: string,
+  model: string,
+  prompt: string,
 ): Promise<TranscriptionSummaryLog> {
   const res = await fetch(`${BASE_URL}/interview/summarize`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ transcriptionId }),
+    body: JSON.stringify({ transcriptionId, model, prompt }),
   });
   if (!res.ok) {
     throw new Error(`要約の生成に失敗しました: ${res.status}`);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,7 @@ import type {
   InterviewAnalysisSummary,
   Transcription,
   TranscriptionSummary,
+  TranscriptionSummaryLog,
 } from '../types';
 
 /**
@@ -731,6 +732,44 @@ export async function transcribePodcastFile(
   }
   const data = await res.json();
   return data.transcription;
+}
+
+// === 要約 ===
+
+/** 要約を生成 */
+export async function summarizeTranscription(
+  transcriptionId: string,
+): Promise<TranscriptionSummaryLog> {
+  const res = await fetch(`${BASE_URL}/interview/summarize`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ transcriptionId }),
+  });
+  if (!res.ok) {
+    throw new Error(`要約の生成に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.summary;
+}
+
+/** 要約ログ一覧を取得 */
+export async function fetchSummaryLogs(): Promise<TranscriptionSummaryLog[]> {
+  const res = await fetch(`${BASE_URL}/interview/summary-logs`);
+  if (!res.ok) {
+    throw new Error(`要約ログ一覧の取得に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.logs;
+}
+
+/** 要約ログ詳細を取得 */
+export async function fetchSummaryLog(id: string): Promise<TranscriptionSummaryLog> {
+  const res = await fetch(`${BASE_URL}/interview/summary-logs/${encodeURIComponent(id)}`);
+  if (!res.ok) {
+    throw new Error(`要約ログの取得に失敗しました: ${res.status}`);
+  }
+  const data = await res.json();
+  return data.log;
 }
 
 // === 設定 ===

--- a/frontend/src/components/InterviewPage.css
+++ b/frontend/src/components/InterviewPage.css
@@ -177,6 +177,7 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  margin-top: 2rem;
 }
 
 .interview-result-card {

--- a/frontend/src/components/KeywordList.tsx
+++ b/frontend/src/components/KeywordList.tsx
@@ -8,6 +8,7 @@ interface Props {
   onToggleKeyword: (keyword: string) => void;
   filterActive: boolean;
   onToggleFilter: () => void;
+  onNavigateSummary?: () => void;
   onNavigateInterview?: () => void;
   onNavigateDeepSearch?: () => void;
   onToggleContextMode?: () => void;
@@ -24,6 +25,7 @@ export function KeywordList({
   onToggleKeyword,
   filterActive,
   onToggleFilter,
+  onNavigateSummary,
   onNavigateInterview,
   onNavigateDeepSearch,
   onToggleContextMode,
@@ -51,6 +53,14 @@ export function KeywordList({
 
   return (
     <div className="keyword-list">
+      {onNavigateSummary && (
+        <button
+          className="keyword-interview-button"
+          onClick={onNavigateSummary}
+        >
+          要約
+        </button>
+      )}
       {onNavigateInterview && (
         <button
           className="keyword-interview-button"

--- a/frontend/src/components/SettingsPage.tsx
+++ b/frontend/src/components/SettingsPage.tsx
@@ -108,6 +108,7 @@ export default function SettingsPage({ onBack }: SettingsPageProps) {
     { label: '文字起こし', path: 'transcriptions/' },
     { label: 'PDFドキュメント', path: 'documents/' },
     { label: 'メタデータ', path: 'document-metadata/' },
+    { label: '要約ログ', path: 'summary-logs/' },
   ];
 
   return (

--- a/frontend/src/components/SummaryPage.css
+++ b/frontend/src/components/SummaryPage.css
@@ -1,48 +1,20 @@
-/* モデル選択 */
-.summary-model-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.summary-model-option {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.6rem 0.75rem;
+/* モデル選択セレクトボックス */
+.summary-model-select {
+  padding: 0.5rem 0.75rem;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background-color: #ffffff;
-  cursor: pointer;
-  transition: background-color 0.15s;
-}
-
-.summary-model-option:has(input:checked) {
-  background-color: #eff6ff;
-  border-color: #93c5fd;
-}
-
-.summary-model-option:hover {
-  background-color: #f9fafb;
-}
-
-.summary-model-option input[type="radio"] {
-  accent-color: #3b82f6;
-  width: 1rem;
-  height: 1rem;
-  flex-shrink: 0;
-}
-
-.summary-model-label {
   font-size: 0.9rem;
-  font-weight: 500;
   color: #1f2937;
+  cursor: pointer;
+  min-width: 280px;
+  transition: border-color 0.15s;
 }
 
-.summary-model-id {
-  font-size: 0.75rem;
-  color: #9ca3af;
-  margin-left: auto;
+.summary-model-select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
 }
 
 /* プロンプトセクションヘッダー */
@@ -74,29 +46,149 @@
   color: #374151;
 }
 
-/* プロンプトテキストエリア */
-.summary-prompt-textarea {
-  width: 100%;
-  padding: 0.75rem;
+/* 指示フォーム */
+.summary-fields-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.summary-field-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-  font-size: 0.85rem;
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
-  line-height: 1.6;
-  color: #1f2937;
   background-color: #ffffff;
-  resize: vertical;
+}
+
+.summary-field-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #374151;
+  white-space: nowrap;
+  min-width: 7rem;
+  flex-shrink: 0;
+}
+
+/* グループフィールド（key_points / actions） */
+.summary-field-group {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background-color: #ffffff;
+  overflow: hidden;
+}
+
+.summary-field-group-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #374151;
+  padding: 0.5rem 0.75rem 0.3rem;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.summary-field-group-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.summary-field-subrow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.4rem 0.75rem;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.summary-field-subrow:last-child {
+  border-bottom: none;
+}
+
+.summary-field-sublabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+  white-space: nowrap;
+  min-width: 4rem;
+  flex-shrink: 0;
+}
+
+.summary-field-instruction {
+  width: 100%;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid #dbeafe;
+  border-radius: 6px;
+  font-size: 0.82rem;
+  color: #374151;
+  background-color: #ffffff;
   box-sizing: border-box;
   transition: border-color 0.15s;
 }
 
-.summary-prompt-textarea:focus {
-  outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+.summary-field-instruction::placeholder {
+  color: #9ca3af;
 }
 
-/* バリデーション */
+.summary-field-instruction:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+/* プロンプトプレビュー */
+.summary-prompt-preview {
+  margin-top: 0.75rem;
+}
+
+.summary-prompt-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.4rem;
+}
+
+.summary-prompt-preview-label {
+  font-size: 0.8rem;
+  color: #6b7280;
+  margin: 0;
+}
+
+.summary-prompt-update-button {
+  padding: 0.25rem 0.65rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #374151;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.summary-prompt-update-button:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+}
+
+.summary-prompt-preview-content {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background-color: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+  line-height: 1.6;
+  color: #374151;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+/* バリデーション警告 */
 .summary-prompt-warning {
   margin-top: 0.5rem;
   padding: 0.5rem 0.75rem;
@@ -107,14 +199,46 @@
   color: #92400e;
 }
 
-.summary-prompt-ok {
-  margin-top: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background-color: #f0fdf4;
-  border: 1px solid #bbf7d0;
-  border-radius: 6px;
-  font-size: 0.8rem;
-  color: #166534;
+/* ログ詳細のデバッグ情報（モデル・プロンプト） */
+.summary-log-debug {
+  margin-top: 1.5rem;
+  padding: 0.75rem;
+  background-color: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.summary-log-debug-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.summary-log-debug-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #9ca3af;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.summary-log-debug-value {
+  font-size: 0.82rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+  color: #374151;
+}
+
+.summary-log-debug-prompt {
+  margin: 0;
+  font-size: 0.78rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+  color: #374151;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* ログ一覧のモデル表示 */
@@ -154,4 +278,50 @@
   color: #9ca3af;
   text-align: right;
   padding-top: 0.5rem;
+}
+
+.summary-key-points li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  list-style: none;
+  border-left: 3px solid #e5e7eb;
+  padding-left: 0.75rem;
+}
+
+.summary-key-point-topic {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #111827;
+}
+
+.summary-key-point-summary {
+  font-size: 0.85rem;
+  color: #6b7280;
+  line-height: 1.6;
+}
+
+.summary-actions li {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  list-style: none;
+  padding-left: 0;
+}
+
+.summary-action-speaker {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: #4b5563;
+  border-radius: 4px;
+  padding: 0.1rem 0.5rem;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.summary-action-task {
+  font-size: 0.9rem;
+  color: #374151;
+  line-height: 1.6;
 }

--- a/frontend/src/components/SummaryPage.css
+++ b/frontend/src/components/SummaryPage.css
@@ -1,0 +1,157 @@
+/* モデル選択 */
+.summary-model-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.summary-model-option {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background-color: #ffffff;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.summary-model-option:has(input:checked) {
+  background-color: #eff6ff;
+  border-color: #93c5fd;
+}
+
+.summary-model-option:hover {
+  background-color: #f9fafb;
+}
+
+.summary-model-option input[type="radio"] {
+  accent-color: #3b82f6;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+.summary-model-label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: #1f2937;
+}
+
+.summary-model-id {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin-left: auto;
+}
+
+/* プロンプトセクションヘッダー */
+.summary-prompt-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.summary-prompt-header h2 {
+  margin-bottom: 0 !important;
+}
+
+.summary-reset-button {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background-color: #ffffff;
+  color: #6b7280;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.summary-reset-button:hover {
+  background-color: #f3f4f6;
+  border-color: #9ca3af;
+  color: #374151;
+}
+
+/* プロンプトテキストエリア */
+.summary-prompt-textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Consolas, monospace;
+  line-height: 1.6;
+  color: #1f2937;
+  background-color: #ffffff;
+  resize: vertical;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.summary-prompt-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* バリデーション */
+.summary-prompt-warning {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #92400e;
+}
+
+.summary-prompt-ok {
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  color: #166534;
+}
+
+/* ログ一覧のモデル表示 */
+.summary-log-model {
+  font-size: 0.7rem;
+  color: #9ca3af;
+  margin-top: 0.2rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* 要約結果表示 */
+.summary-result-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.summary-result-list li {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #374151;
+}
+
+.summary-result-text {
+  font-size: 0.9rem;
+  line-height: 1.7;
+  color: #374151;
+  margin: 0;
+}
+
+.summary-result-meta {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  text-align: right;
+  padding-top: 0.5rem;
+}

--- a/frontend/src/components/SummaryPage.css
+++ b/frontend/src/components/SummaryPage.css
@@ -325,3 +325,34 @@
   color: #374151;
   line-height: 1.6;
 }
+
+.summary-completed {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.25rem;
+  padding: 1rem 1.25rem;
+  background-color: #f0fdf4;
+  border: 1px solid #bbf7d0;
+  border-radius: 8px;
+}
+
+.summary-completed-message {
+  font-size: 0.9rem;
+  color: #15803d;
+  font-weight: 500;
+}
+
+.summary-completed-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.9rem;
+  color: #1d4ed8;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.summary-completed-link:hover {
+  color: #1e40af;
+}

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+import { summarizeTranscription, fetchSummaryLogs, fetchSummaryLog } from '../api/client';
+import type { TranscriptionSummaryLog } from '../types';
+import './InterviewPage.css';
+
+interface Props {
+  transcriptionId: string;
+  onBack: () => void;
+}
+
+/** 要約ページ */
+export function SummaryPage({ transcriptionId, onBack }: Props) {
+  const [activeTab, setActiveTab] = useState<'new' | 'logs'>('new');
+  const [summarizing, setSummarizing] = useState(false);
+  const [summary, setSummary] = useState<TranscriptionSummaryLog | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [logs, setLogs] = useState<TranscriptionSummaryLog[]>([]);
+  const [logsLoading, setLogsLoading] = useState(false);
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
+  const [logDetail, setLogDetail] = useState<TranscriptionSummaryLog | null>(null);
+  const [logDetailLoading, setLogDetailLoading] = useState(false);
+
+  const loadLogs = async () => {
+    setLogsLoading(true);
+    try {
+      const all = await fetchSummaryLogs();
+      const filtered = all
+        .filter((l) => l.transcriptionId === transcriptionId)
+        .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+      setLogs(filtered);
+    } catch {
+      // ログ取得失敗は無視
+    } finally {
+      setLogsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (activeTab === 'logs') {
+      loadLogs();
+    }
+  }, [activeTab]);
+
+  const handleSelectLog = async (id: string) => {
+    setSelectedLogId(id);
+    setLogDetail(null);
+    setLogDetailLoading(true);
+    try {
+      const detail = await fetchSummaryLog(id);
+      setLogDetail(detail);
+    } catch {
+      setLogDetail(null);
+    } finally {
+      setLogDetailLoading(false);
+    }
+  };
+
+  const handleSummarize = async () => {
+    setSummarizing(true);
+    setError(null);
+    try {
+      const result = await summarizeTranscription(transcriptionId);
+      setSummary(result);
+      loadLogs();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : '要約に失敗しました');
+    } finally {
+      setSummarizing(false);
+    }
+  };
+
+  const formatDate = (iso: string) => {
+    const d = new Date(iso);
+    return d.toLocaleString('ja-JP', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+  };
+
+  return (
+    <div className="interview-page">
+      <header className="interview-header">
+        <button className="interview-back-button" onClick={onBack}>
+          ← 戻る
+        </button>
+        <h1>要約</h1>
+      </header>
+
+      <div className="interview-tabs">
+        <button
+          className={`interview-tab ${activeTab === 'new' ? 'active' : ''}`}
+          onClick={() => setActiveTab('new')}
+        >
+          新規要約
+        </button>
+        <button
+          className={`interview-tab ${activeTab === 'logs' ? 'active' : ''}`}
+          onClick={() => setActiveTab('logs')}
+        >
+          過去の要約ログ
+        </button>
+      </div>
+
+      {activeTab === 'new' && (
+        <div className="interview-content">
+          {error && <div className="interview-error">{error}</div>}
+
+          <section className="interview-section">
+            <div className="interview-actions">
+              <button
+                className="interview-button primary"
+                onClick={handleSummarize}
+                disabled={summarizing}
+              >
+                {summarizing ? '要約中...' : '要約する'}
+              </button>
+            </div>
+
+            {summarizing && (
+              <div className="interview-loading">
+                <div className="loading-spinner" />
+                <p>Claude が会話を要約中...</p>
+              </div>
+            )}
+
+            {summary && !summarizing && <SummaryResult summary={summary} formatDate={formatDate} />}
+          </section>
+        </div>
+      )}
+
+      {activeTab === 'logs' && (
+        <div className="interview-logs-layout">
+          <div className="interview-logs-list">
+            <div className="interview-logs-list-header">
+              <span>要約履歴</span>
+              <button
+                className="interview-logs-refresh"
+                onClick={loadLogs}
+                disabled={logsLoading}
+                title="更新"
+              >
+                ↻
+              </button>
+            </div>
+            {logsLoading ? (
+              <div className="interview-logs-empty">読み込み中...</div>
+            ) : logs.length === 0 ? (
+              <div className="interview-logs-empty">過去の要約結果がありません</div>
+            ) : (
+              logs.map((log) => (
+                <button
+                  key={log.id}
+                  className={`interview-log-item ${selectedLogId === log.id ? 'selected' : ''}`}
+                  onClick={() => handleSelectLog(log.id)}
+                >
+                  <div className="interview-log-item-date">{formatDate(log.createdAt)}</div>
+                  <div className="interview-log-item-keywords">
+                    {log.topics.slice(0, 2).join('・')}
+                    {log.topics.length > 2 && ` 他${log.topics.length - 2}件`}
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+
+          <div className="interview-logs-detail">
+            {!selectedLogId && (
+              <div className="interview-logs-detail-empty">
+                左の一覧から要約結果を選択してください
+              </div>
+            )}
+            {selectedLogId && logDetailLoading && (
+              <div className="interview-logs-detail-empty">読み込み中...</div>
+            )}
+            {selectedLogId && !logDetailLoading && logDetail && (
+              <>
+                <div className="interview-logs-detail-header">
+                  <div className="interview-logs-detail-meta">
+                    <span className="interview-logs-detail-date">
+                      {formatDate(logDetail.createdAt)}
+                    </span>
+                  </div>
+                </div>
+                <SummaryResult summary={logDetail} formatDate={formatDate} />
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 要約結果表示（新規・過去ログ共通） */
+function SummaryResult({
+  summary,
+  formatDate,
+}: {
+  summary: TranscriptionSummaryLog;
+  formatDate: (iso: string) => string;
+}) {
+  return (
+    <div className="interview-results">
+      <div className="interview-result-card">
+        <h3 className="result-question">主なトピック</h3>
+        <ul style={{ paddingLeft: '1.25rem', margin: '0.5rem 0' }}>
+          {summary.topics.map((topic, i) => (
+            <li key={i} style={{ marginBottom: '0.25rem' }}>{topic}</li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="interview-result-card">
+        <h3 className="result-question">結論・合意事項</h3>
+        <p style={{ margin: '0.5rem 0', lineHeight: 1.7 }}>{summary.conclusion}</p>
+      </div>
+
+      {summary.actions.length > 0 && (
+        <div className="interview-result-card">
+          <h3 className="result-question">次のアクション</h3>
+          <ul style={{ paddingLeft: '1.25rem', margin: '0.5rem 0' }}>
+            {summary.actions.map((action, i) => (
+              <li key={i} style={{ marginBottom: '0.25rem' }}>{action}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.5rem' }}>
+        生成日時: {formatDate(summary.createdAt)}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -168,9 +168,6 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
     setFields((prev) => prev.map((f) => (f.key === key ? { ...f, instruction: value } : { ...f })));
   };
 
-  const hasInstruction = (key: PromptFieldConfig['key']) =>
-    fields.find((f) => f.key === key)?.instruction.trim() !== '';
-
   const handleResetFields = () => {
     setFields(DEFAULT_FIELDS.map((f) => ({ ...f })));
   };
@@ -539,7 +536,7 @@ function SummaryResult({
         <div className="interview-result-card">
           <h3 className="result-question">キーポイント</h3>
           <ul className="summary-result-list summary-key-points">
-            {summary.key_points.map((kp: SummaryKeyPoint, i: number) => (
+            {summary.key_points?.map((kp: SummaryKeyPoint, i: number) => (
               <li key={i}>
                 <span className="summary-key-point-topic">{kp.topic}</span>
                 <span className="summary-key-point-summary">{kp.summary}</span>
@@ -553,7 +550,7 @@ function SummaryResult({
         <div className="interview-result-card">
           <h3 className="result-question">決定事項</h3>
           <ul className="summary-result-list">
-            {summary.decisions.map((decision: string, i: number) => (
+            {summary.decisions?.map((decision: string, i: number) => (
               <li key={i}>{decision}</li>
             ))}
           </ul>
@@ -564,7 +561,7 @@ function SummaryResult({
         <div className="interview-result-card">
           <h3 className="result-question">次のアクション</h3>
           <ul className="summary-result-list summary-actions">
-            {summary.actions.map((action: SummaryActionItem, i: number) => (
+            {summary.actions?.map((action: SummaryActionItem, i: number) => (
               <li key={i}>
                 <span className="summary-action-speaker">{action.speaker}</span>
                 <span className="summary-action-task">{action.task}</span>
@@ -578,7 +575,7 @@ function SummaryResult({
         <div className="interview-result-card">
           <h3 className="result-question">未解決の質問</h3>
           <ul className="summary-result-list">
-            {summary.open_questions.map((q: string, i: number) => (
+            {summary.open_questions?.map((q: string, i: number) => (
               <li key={i}>{q}</li>
             ))}
           </ul>

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useState } from 'react';
-import { summarizeTranscription, fetchSummaryLogs, fetchSummaryLog } from '../api/client';
-import type { TranscriptionSummaryLog } from '../types';
+import { summarizeTranscription, fetchSummaryLogs, fetchSummaryLog, fetchSummaryConfig } from '../api/client';
+import type { SummaryConfig, TranscriptionSummaryLog } from '../types';
 import './InterviewPage.css';
+import './SummaryPage.css';
 
 interface Props {
   transcriptionId: string;
   onBack: () => void;
+}
+
+/** プロンプトに必須キーが含まれているか検証 */
+function validatePrompt(prompt: string): string[] {
+  const required = ['"topics"', '"conclusion"', '"actions"'];
+  return required.filter((key) => !prompt.includes(key));
 }
 
 /** 要約ページ */
@@ -15,11 +22,40 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
   const [summary, setSummary] = useState<TranscriptionSummaryLog | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // 設定（モデル一覧・デフォルトプロンプト）
+  const [config, setConfig] = useState<SummaryConfig | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string>('');
+  const [promptText, setPromptText] = useState<string>('');
+  const [promptWarnings, setPromptWarnings] = useState<string[]>([]);
+
+  // 過去ログ
   const [logs, setLogs] = useState<TranscriptionSummaryLog[]>([]);
   const [logsLoading, setLogsLoading] = useState(false);
   const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
   const [logDetail, setLogDetail] = useState<TranscriptionSummaryLog | null>(null);
   const [logDetailLoading, setLogDetailLoading] = useState(false);
+
+  // 初期ロード: 設定取得
+  useEffect(() => {
+    fetchSummaryConfig()
+      .then((c) => {
+        setConfig(c);
+        setSelectedModel(c.models[0]?.id ?? '');
+        setPromptText(c.defaultPrompt);
+      })
+      .catch(() => {
+        setError('設定の読み込みに失敗しました');
+      });
+  }, []);
+
+  // プロンプト変更時にバリデーション
+  useEffect(() => {
+    setPromptWarnings(validatePrompt(promptText));
+  }, [promptText]);
+
+  const handleResetPrompt = () => {
+    if (config) setPromptText(config.defaultPrompt);
+  };
 
   const loadLogs = async () => {
     setLogsLoading(true);
@@ -57,10 +93,11 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
   };
 
   const handleSummarize = async () => {
+    if (!selectedModel || !promptText) return;
     setSummarizing(true);
     setError(null);
     try {
-      const result = await summarizeTranscription(transcriptionId);
+      const result = await summarizeTranscription(transcriptionId, selectedModel, promptText);
       setSummary(result);
       loadLogs();
     } catch (e) {
@@ -80,6 +117,8 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
       minute: '2-digit',
     });
   };
+
+  const isPromptChanged = config ? promptText !== config.defaultPrompt : false;
 
   return (
     <div className="interview-page">
@@ -109,12 +148,71 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
         <div className="interview-content">
           {error && <div className="interview-error">{error}</div>}
 
+          {/* モデル選択 */}
+          <section className="interview-section">
+            <h2>モデル選択</h2>
+            {config ? (
+              <div className="summary-model-list">
+                {config.models.map((m) => (
+                  <label key={m.id} className="summary-model-option">
+                    <input
+                      type="radio"
+                      name="model"
+                      value={m.id}
+                      checked={selectedModel === m.id}
+                      onChange={() => setSelectedModel(m.id)}
+                    />
+                    <span className="summary-model-label">{m.label}</span>
+                    <span className="summary-model-id">{m.id}</span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="interview-hint">読み込み中...</p>
+            )}
+          </section>
+
+          {/* プロンプトテンプレート */}
+          <section className="interview-section">
+            <div className="summary-prompt-header">
+              <h2>プロンプトテンプレート</h2>
+              {isPromptChanged && (
+                <button
+                  className="summary-reset-button"
+                  onClick={handleResetPrompt}
+                  title="デフォルトに戻す"
+                >
+                  テンプレートに戻す
+                </button>
+              )}
+            </div>
+            <p className="interview-hint">
+              <code>{'{{fullText}}'}</code> が会話全文に置換されます
+            </p>
+            <textarea
+              className="summary-prompt-textarea"
+              value={promptText}
+              onChange={(e) => setPromptText(e.target.value)}
+              rows={14}
+              spellCheck={false}
+            />
+            {promptWarnings.length > 0 ? (
+              <div className="summary-prompt-warning">
+                ⚠ 出力形式に必須キーが見つかりません: {promptWarnings.join(', ')}
+                （このまま実行することもできます）
+              </div>
+            ) : (
+              <div className="summary-prompt-ok">✓ フォーマット正常</div>
+            )}
+          </section>
+
+          {/* 実行ボタン */}
           <section className="interview-section">
             <div className="interview-actions">
               <button
                 className="interview-button primary"
                 onClick={handleSummarize}
-                disabled={summarizing}
+                disabled={summarizing || !selectedModel || !promptText}
               >
                 {summarizing ? '要約中...' : '要約する'}
               </button>
@@ -127,7 +225,9 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
               </div>
             )}
 
-            {summary && !summarizing && <SummaryResult summary={summary} formatDate={formatDate} />}
+            {summary && !summarizing && (
+              <SummaryResult summary={summary} formatDate={formatDate} />
+            )}
           </section>
         </div>
       )}
@@ -162,6 +262,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
                     {log.topics.slice(0, 2).join('・')}
                     {log.topics.length > 2 && ` 他${log.topics.length - 2}件`}
                   </div>
+                  <div className="summary-log-model">{log.model}</div>
                 </button>
               ))
             )}
@@ -183,6 +284,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
                     <span className="interview-logs-detail-date">
                       {formatDate(logDetail.createdAt)}
                     </span>
+                    <span className="summary-log-model">{logDetail.model}</span>
                   </div>
                 </div>
                 <SummaryResult summary={logDetail} formatDate={formatDate} />
@@ -207,31 +309,31 @@ function SummaryResult({
     <div className="interview-results">
       <div className="interview-result-card">
         <h3 className="result-question">主なトピック</h3>
-        <ul style={{ paddingLeft: '1.25rem', margin: '0.5rem 0' }}>
+        <ul className="summary-result-list">
           {summary.topics.map((topic, i) => (
-            <li key={i} style={{ marginBottom: '0.25rem' }}>{topic}</li>
+            <li key={i}>{topic}</li>
           ))}
         </ul>
       </div>
 
       <div className="interview-result-card">
         <h3 className="result-question">結論・合意事項</h3>
-        <p style={{ margin: '0.5rem 0', lineHeight: 1.7 }}>{summary.conclusion}</p>
+        <p className="summary-result-text">{summary.conclusion}</p>
       </div>
 
       {summary.actions.length > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">次のアクション</h3>
-          <ul style={{ paddingLeft: '1.25rem', margin: '0.5rem 0' }}>
+          <ul className="summary-result-list">
             {summary.actions.map((action, i) => (
-              <li key={i} style={{ marginBottom: '0.25rem' }}>{action}</li>
+              <li key={i}>{action}</li>
             ))}
           </ul>
         </div>
       )}
 
-      <div style={{ fontSize: '0.75rem', color: '#9ca3af', marginTop: '0.5rem' }}>
-        生成日時: {formatDate(summary.createdAt)}
+      <div className="summary-result-meta">
+        生成日時: {formatDate(summary.createdAt)} / モデル: {summary.model}
       </div>
     </div>
   );

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -532,7 +532,7 @@ function SummaryResult({
         </div>
       )}
 
-      {summary.key_points?.length > 0 && (
+      {(summary.key_points?.length ?? 0) > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">キーポイント</h3>
           <ul className="summary-result-list summary-key-points">
@@ -546,7 +546,7 @@ function SummaryResult({
         </div>
       )}
 
-      {summary.decisions?.length > 0 && (
+      {(summary.decisions?.length ?? 0) > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">決定事項</h3>
           <ul className="summary-result-list">
@@ -557,7 +557,7 @@ function SummaryResult({
         </div>
       )}
 
-      {summary.actions?.length > 0 && (
+      {(summary.actions?.length ?? 0) > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">次のアクション</h3>
           <ul className="summary-result-list summary-actions">
@@ -571,7 +571,7 @@ function SummaryResult({
         </div>
       )}
 
-      {summary.open_questions?.length > 0 && (
+      {(summary.open_questions?.length ?? 0) > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">未解決の質問</h3>
           <ul className="summary-result-list">

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { summarizeTranscription, fetchSummaryLogs, fetchSummaryLog, fetchSummaryConfig } from '../api/client';
-import type { SummaryConfig, TranscriptionSummaryLog, SummaryKeyPoint, SummaryActionItem } from '../types';
+import type { SummaryConfig, TranscriptionSummaryLog, SummaryKeyPoint } from '../types';
 import './InterviewPage.css';
 import './SummaryPage.css';
 
@@ -11,9 +11,9 @@ interface Props {
 
 /** プロンプト指示フォームの各フィールド設定 */
 interface PromptFieldConfig {
-  key: 'overview' | 'key_points_topic' | 'key_points_summary' | 'decisions' | 'actions_speaker' | 'actions_task' | 'open_questions';
+  key: 'overview' | 'key_points_topic' | 'key_points_summary' | 'decisions';
   /** JSONの親キー。サブフィールドは同じgroupKeyを持つ */
-  groupKey: 'overview' | 'key_points' | 'decisions' | 'actions' | 'open_questions';
+  groupKey: 'overview' | 'key_points' | 'decisions';
   label: string;
   subLabel?: string;
   defaultInstruction: string;
@@ -51,29 +51,6 @@ const DEFAULT_FIELDS: PromptFieldConfig[] = [
     defaultInstruction: '会話中に明示的に合意・決定された事項を列挙する',
     instruction: '会話中に明示的に合意・決定された事項を列挙する',
   },
-  {
-    key: 'actions_speaker',
-    groupKey: 'actions',
-    label: '次のアクション',
-    subLabel: 'speaker',
-    defaultInstruction: '担当する話者名。不明な場合は「未定」とする',
-    instruction: '担当する話者名。不明な場合は「未定」とする',
-  },
-  {
-    key: 'actions_task',
-    groupKey: 'actions',
-    label: '次のアクション',
-    subLabel: 'task',
-    defaultInstruction: '次のステップを動詞句で記述する',
-    instruction: '次のステップを動詞句で記述する',
-  },
-  {
-    key: 'open_questions',
-    groupKey: 'open_questions',
-    label: '未解決の質問',
-    defaultInstruction: '結論が出なかった質問・持ち越し事項を列挙する',
-    instruction: '結論が出なかった質問・持ち越し事項を列挙する',
-  },
 ];
 
 /** フィールド設定からプロンプトを生成（instructionが空のフィールドは除外） */
@@ -97,18 +74,6 @@ function buildPrompt(fields: PromptFieldConfig[]): string {
 
   if (get('decisions')) {
     lines.push(`  "decisions": ["${get('decisions')}"]`);
-  }
-
-  const actSpeaker = get('actions_speaker');
-  const actTask = get('actions_task');
-  if (actSpeaker || actTask) {
-    lines.push(
-      `  "actions": [{\n    "speaker": "${actSpeaker || '（省略）'}",\n    "task": "${actTask || '（省略）'}"\n  }]`,
-    );
-  }
-
-  if (get('open_questions')) {
-    lines.push(`  "open_questions": ["${get('open_questions')}"]`);
   }
 
   const jsonShape = lines.join(',\n');
@@ -353,39 +318,6 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
                 />
               </div>
 
-              {/* actions（グループ） */}
-              <div className="summary-field-group">
-                <span className="summary-field-group-label">次のアクション</span>
-                <div className="summary-field-group-rows">
-                  {(['actions_speaker', 'actions_task'] as const).map((key) => {
-                    const f = fields.find((f) => f.key === key)!;
-                    return (
-                      <div key={key} className="summary-field-subrow">
-                        <span className="summary-field-sublabel">{f.subLabel}</span>
-                        <input
-                          type="text"
-                          className="summary-field-instruction"
-                          placeholder={f.defaultInstruction}
-                          value={f.instruction}
-                          onChange={(e) => handleFieldInstruction(key, e.target.value)}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* open_questions */}
-              <div className="summary-field-row">
-                <span className="summary-field-label">未解決の質問</span>
-                <input
-                  type="text"
-                  className="summary-field-instruction"
-                  placeholder={fields.find((f) => f.key === 'open_questions')!.defaultInstruction}
-                  value={fields.find((f) => f.key === 'open_questions')!.instruction}
-                  onChange={(e) => handleFieldInstruction('open_questions', e.target.value)}
-                />
-              </div>
             </div>
             {enabledCount === 0 && (
               <div className="summary-prompt-warning">
@@ -552,31 +484,6 @@ function SummaryResult({
           <ul className="summary-result-list">
             {summary.decisions?.map((decision: string, i: number) => (
               <li key={i}>{decision}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {(summary.actions?.length ?? 0) > 0 && (
-        <div className="interview-result-card">
-          <h3 className="result-question">次のアクション</h3>
-          <ul className="summary-result-list summary-actions">
-            {summary.actions?.map((action: SummaryActionItem, i: number) => (
-              <li key={i}>
-                <span className="summary-action-speaker">{action.speaker}</span>
-                <span className="summary-action-task">{action.task}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {(summary.open_questions?.length ?? 0) > 0 && (
-        <div className="interview-result-card">
-          <h3 className="result-question">未解決の質問</h3>
-          <ul className="summary-result-list">
-            {summary.open_questions?.map((q: string, i: number) => (
-              <li key={i}>{q}</li>
             ))}
           </ul>
         </div>

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { summarizeTranscription, fetchSummaryLogs, fetchSummaryLog, fetchSummaryConfig } from '../api/client';
-import type { SummaryConfig, TranscriptionSummaryLog } from '../types';
+import type { SummaryConfig, TranscriptionSummaryLog, SummaryKeyPoint, SummaryActionItem } from '../types';
 import './InterviewPage.css';
 import './SummaryPage.css';
 
@@ -9,10 +9,123 @@ interface Props {
   onBack: () => void;
 }
 
-/** プロンプトに必須キーが含まれているか検証 */
-function validatePrompt(prompt: string): string[] {
-  const required = ['"topics"', '"conclusion"', '"actions"'];
-  return required.filter((key) => !prompt.includes(key));
+/** プロンプト指示フォームの各フィールド設定 */
+interface PromptFieldConfig {
+  key: 'overview' | 'key_points_topic' | 'key_points_summary' | 'decisions' | 'actions_speaker' | 'actions_task' | 'open_questions';
+  /** JSONの親キー。サブフィールドは同じgroupKeyを持つ */
+  groupKey: 'overview' | 'key_points' | 'decisions' | 'actions' | 'open_questions';
+  label: string;
+  subLabel?: string;
+  defaultInstruction: string;
+  instruction: string;
+}
+
+const DEFAULT_FIELDS: PromptFieldConfig[] = [
+  {
+    key: 'overview',
+    groupKey: 'overview',
+    label: '概要',
+    defaultInstruction: '会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる',
+    instruction: '会話の目的・流れ・結果を第三者が読んで理解できるよう2〜3文でまとめる',
+  },
+  {
+    key: 'key_points_topic',
+    groupKey: 'key_points',
+    label: 'キーポイント',
+    subLabel: 'topic',
+    defaultInstruction: '話題のテーマ名を名詞句で記述する',
+    instruction: '話題のテーマ名を名詞句で記述する',
+  },
+  {
+    key: 'key_points_summary',
+    groupKey: 'key_points',
+    label: 'キーポイント',
+    subLabel: 'summary',
+    defaultInstruction: '各トピックの要点を2〜3文で記述する',
+    instruction: '各トピックの要点を2〜3文で記述する',
+  },
+  {
+    key: 'decisions',
+    groupKey: 'decisions',
+    label: '決定事項',
+    defaultInstruction: '会話中に明示的に合意・決定された事項を列挙する',
+    instruction: '会話中に明示的に合意・決定された事項を列挙する',
+  },
+  {
+    key: 'actions_speaker',
+    groupKey: 'actions',
+    label: '次のアクション',
+    subLabel: 'speaker',
+    defaultInstruction: '担当する話者名。不明な場合は「未定」とする',
+    instruction: '担当する話者名。不明な場合は「未定」とする',
+  },
+  {
+    key: 'actions_task',
+    groupKey: 'actions',
+    label: '次のアクション',
+    subLabel: 'task',
+    defaultInstruction: '次のステップを動詞句で記述する',
+    instruction: '次のステップを動詞句で記述する',
+  },
+  {
+    key: 'open_questions',
+    groupKey: 'open_questions',
+    label: '未解決の質問',
+    defaultInstruction: '結論が出なかった質問・持ち越し事項を列挙する',
+    instruction: '結論が出なかった質問・持ち越し事項を列挙する',
+  },
+];
+
+/** フィールド設定からプロンプトを生成（instructionが空のフィールドは除外） */
+function buildPrompt(fields: PromptFieldConfig[]): string {
+  const get = (key: PromptFieldConfig['key']) =>
+    fields.find((f) => f.key === key)?.instruction.trim() ?? '';
+
+  const lines: string[] = [];
+
+  if (get('overview')) {
+    lines.push(`  "overview": "${get('overview')}"`);
+  }
+
+  const kpTopic = get('key_points_topic');
+  const kpSummary = get('key_points_summary');
+  if (kpTopic || kpSummary) {
+    lines.push(
+      `  "key_points": [{\n    "topic": "${kpTopic || '（省略）'}",\n    "summary": "${kpSummary || '（省略）'}"\n  }]`,
+    );
+  }
+
+  if (get('decisions')) {
+    lines.push(`  "decisions": ["${get('decisions')}"]`);
+  }
+
+  const actSpeaker = get('actions_speaker');
+  const actTask = get('actions_task');
+  if (actSpeaker || actTask) {
+    lines.push(
+      `  "actions": [{\n    "speaker": "${actSpeaker || '（省略）'}",\n    "task": "${actTask || '（省略）'}"\n  }]`,
+    );
+  }
+
+  if (get('open_questions')) {
+    lines.push(`  "open_questions": ["${get('open_questions')}"]`);
+  }
+
+  const jsonShape = lines.join(',\n');
+
+  return `あなたは会議・インタビューの文字起こしを要約するアシスタントです。
+
+<conversation>
+{{fullText}}
+</conversation>
+
+<instructions>
+上記の会話を分析し、以下のJSON形式のみで出力してください。JSONの前後に説明文やコードブロック記号（\`\`\`）を含めないでください。
+
+{
+${jsonShape}
+}
+</instructions>`;
 }
 
 /** 要約ページ */
@@ -25,8 +138,12 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
   // 設定（モデル一覧・デフォルトプロンプト）
   const [config, setConfig] = useState<SummaryConfig | null>(null);
   const [selectedModel, setSelectedModel] = useState<string>('');
-  const [promptText, setPromptText] = useState<string>('');
-  const [promptWarnings, setPromptWarnings] = useState<string[]>([]);
+
+  // プロンプト指示フォーム
+  const [fields, setFields] = useState<PromptFieldConfig[]>(DEFAULT_FIELDS);
+  const [previewPrompt, setPreviewPrompt] = useState<string>(() =>
+    buildPrompt(DEFAULT_FIELDS).replace('{{fullText}}', '（会話全文がここに入ります）'),
+  );
 
   // 過去ログ
   const [logs, setLogs] = useState<TranscriptionSummaryLog[]>([]);
@@ -41,21 +158,24 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
       .then((c) => {
         setConfig(c);
         setSelectedModel(c.models[0]?.id ?? '');
-        setPromptText(c.defaultPrompt);
       })
       .catch(() => {
         setError('設定の読み込みに失敗しました');
       });
   }, []);
 
-  // プロンプト変更時にバリデーション
-  useEffect(() => {
-    setPromptWarnings(validatePrompt(promptText));
-  }, [promptText]);
-
-  const handleResetPrompt = () => {
-    if (config) setPromptText(config.defaultPrompt);
+  const handleFieldInstruction = (key: PromptFieldConfig['key'], value: string) => {
+    setFields((prev) => prev.map((f) => (f.key === key ? { ...f, instruction: value } : { ...f })));
   };
+
+  const hasInstruction = (key: PromptFieldConfig['key']) =>
+    fields.find((f) => f.key === key)?.instruction.trim() !== '';
+
+  const handleResetFields = () => {
+    setFields(DEFAULT_FIELDS.map((f) => ({ ...f })));
+  };
+
+  const isFieldsChanged = fields.some((f, i) => f.instruction !== DEFAULT_FIELDS[i].instruction);
 
   const loadLogs = async () => {
     setLogsLoading(true);
@@ -93,11 +213,15 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
   };
 
   const handleSummarize = async () => {
-    if (!selectedModel || !promptText) return;
+    if (!selectedModel) return;
+    const enabledCount = fields.filter((f) => f.instruction.trim() !== '').length;
+    if (enabledCount === 0) return;
+
     setSummarizing(true);
     setError(null);
     try {
-      const result = await summarizeTranscription(transcriptionId, selectedModel, promptText);
+      const prompt = buildPrompt(fields);
+      const result = await summarizeTranscription(transcriptionId, selectedModel, prompt);
       setSummary(result);
       loadLogs();
     } catch (e) {
@@ -118,7 +242,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
     });
   };
 
-  const isPromptChanged = config ? promptText !== config.defaultPrompt : false;
+  const enabledCount = fields.filter((f) => f.instruction.trim() !== '').length;
 
   return (
     <div className="interview-page">
@@ -150,60 +274,147 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
 
           {/* モデル選択 */}
           <section className="interview-section">
-            <h2>モデル選択</h2>
+            <h2>モデル</h2>
             {config ? (
-              <div className="summary-model-list">
+              <select
+                className="summary-model-select"
+                value={selectedModel}
+                onChange={(e) => setSelectedModel(e.target.value)}
+              >
                 {config.models.map((m) => (
-                  <label key={m.id} className="summary-model-option">
-                    <input
-                      type="radio"
-                      name="model"
-                      value={m.id}
-                      checked={selectedModel === m.id}
-                      onChange={() => setSelectedModel(m.id)}
-                    />
-                    <span className="summary-model-label">{m.label}</span>
-                    <span className="summary-model-id">{m.id}</span>
-                  </label>
+                  <option key={m.id} value={m.id}>
+                    {m.id}
+                  </option>
                 ))}
-              </div>
+              </select>
             ) : (
               <p className="interview-hint">読み込み中...</p>
             )}
           </section>
 
-          {/* プロンプトテンプレート */}
+          {/* プロンプト */}
           <section className="interview-section">
             <div className="summary-prompt-header">
-              <h2>プロンプトテンプレート</h2>
-              {isPromptChanged && (
+              <h2>プロンプト</h2>
+              {isFieldsChanged && (
                 <button
                   className="summary-reset-button"
-                  onClick={handleResetPrompt}
+                  onClick={handleResetFields}
                   title="デフォルトに戻す"
                 >
-                  テンプレートに戻す
+                  デフォルトに戻す
                 </button>
               )}
             </div>
             <p className="interview-hint">
-              <code>{'{{fullText}}'}</code> が会話全文に置換されます
+              各項目の指示を編集できます。空にするとその項目は除外されます。
             </p>
-            <textarea
-              className="summary-prompt-textarea"
-              value={promptText}
-              onChange={(e) => setPromptText(e.target.value)}
-              rows={14}
-              spellCheck={false}
-            />
-            {promptWarnings.length > 0 ? (
-              <div className="summary-prompt-warning">
-                ⚠ 出力形式に必須キーが見つかりません: {promptWarnings.join(', ')}
-                （このまま実行することもできます）
+            <div className="summary-fields-form">
+              {/* overview */}
+              <div className="summary-field-row">
+                <span className="summary-field-label">概要</span>
+                <input
+                  type="text"
+                  className="summary-field-instruction"
+                  placeholder={fields.find((f) => f.key === 'overview')!.defaultInstruction}
+                  value={fields.find((f) => f.key === 'overview')!.instruction}
+                  onChange={(e) => handleFieldInstruction('overview', e.target.value)}
+                />
               </div>
-            ) : (
-              <div className="summary-prompt-ok">✓ フォーマット正常</div>
+
+              {/* key_points（グループ） */}
+              <div className="summary-field-group">
+                <span className="summary-field-group-label">キーポイント</span>
+                <div className="summary-field-group-rows">
+                  {(['key_points_topic', 'key_points_summary'] as const).map((key) => {
+                    const f = fields.find((f) => f.key === key)!;
+                    return (
+                      <div key={key} className="summary-field-subrow">
+                        <span className="summary-field-sublabel">{f.subLabel}</span>
+                        <input
+                          type="text"
+                          className="summary-field-instruction"
+                          placeholder={f.defaultInstruction}
+                          value={f.instruction}
+                          onChange={(e) => handleFieldInstruction(key, e.target.value)}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* decisions */}
+              <div className="summary-field-row">
+                <span className="summary-field-label">決定事項</span>
+                <input
+                  type="text"
+                  className="summary-field-instruction"
+                  placeholder={fields.find((f) => f.key === 'decisions')!.defaultInstruction}
+                  value={fields.find((f) => f.key === 'decisions')!.instruction}
+                  onChange={(e) => handleFieldInstruction('decisions', e.target.value)}
+                />
+              </div>
+
+              {/* actions（グループ） */}
+              <div className="summary-field-group">
+                <span className="summary-field-group-label">次のアクション</span>
+                <div className="summary-field-group-rows">
+                  {(['actions_speaker', 'actions_task'] as const).map((key) => {
+                    const f = fields.find((f) => f.key === key)!;
+                    return (
+                      <div key={key} className="summary-field-subrow">
+                        <span className="summary-field-sublabel">{f.subLabel}</span>
+                        <input
+                          type="text"
+                          className="summary-field-instruction"
+                          placeholder={f.defaultInstruction}
+                          value={f.instruction}
+                          onChange={(e) => handleFieldInstruction(key, e.target.value)}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* open_questions */}
+              <div className="summary-field-row">
+                <span className="summary-field-label">未解決の質問</span>
+                <input
+                  type="text"
+                  className="summary-field-instruction"
+                  placeholder={fields.find((f) => f.key === 'open_questions')!.defaultInstruction}
+                  value={fields.find((f) => f.key === 'open_questions')!.instruction}
+                  onChange={(e) => handleFieldInstruction('open_questions', e.target.value)}
+                />
+              </div>
+            </div>
+            {enabledCount === 0 && (
+              <div className="summary-prompt-warning">
+                ⚠ 項目が1つも選択されていません
+              </div>
             )}
+
+            {/* 生成されるプロンプトのプレビュー */}
+            <div className="summary-prompt-preview">
+              <div className="summary-prompt-preview-header">
+                <p className="summary-prompt-preview-label">Claudeへのインプット</p>
+                <button
+                  className="summary-prompt-update-button"
+                  onClick={() =>
+                    setPreviewPrompt(
+                      enabledCount > 0
+                        ? buildPrompt(fields).replace('{{fullText}}', '（会話全文がここに入ります）')
+                        : '（項目がすべて空のためプロンプトは生成されません）',
+                    )
+                  }
+                >
+                  プロンプトを更新
+                </button>
+              </div>
+              <pre className="summary-prompt-preview-content">{previewPrompt}</pre>
+            </div>
           </section>
 
           {/* 実行ボタン */}
@@ -212,7 +423,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
               <button
                 className="interview-button primary"
                 onClick={handleSummarize}
-                disabled={summarizing || !selectedModel || !promptText}
+                disabled={summarizing || !selectedModel || enabledCount === 0}
               >
                 {summarizing ? '要約中...' : '要約する'}
               </button>
@@ -259,8 +470,8 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
                 >
                   <div className="interview-log-item-date">{formatDate(log.createdAt)}</div>
                   <div className="interview-log-item-keywords">
-                    {log.topics.slice(0, 2).join('・')}
-                    {log.topics.length > 2 && ` 他${log.topics.length - 2}件`}
+                    {(log.key_points ?? []).slice(0, 2).map((kp) => kp.topic).join('・')}
+                    {(log.key_points?.length ?? 0) > 2 && ` 他${(log.key_points?.length ?? 0) - 2}件`}
                   </div>
                   <div className="summary-log-model">{log.model}</div>
                 </button>
@@ -288,6 +499,16 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
                   </div>
                 </div>
                 <SummaryResult summary={logDetail} formatDate={formatDate} />
+                <div className="summary-log-debug">
+                  <div className="summary-log-debug-row">
+                    <span className="summary-log-debug-label">モデル</span>
+                    <code className="summary-log-debug-value">{logDetail.model}</code>
+                  </div>
+                  <div className="summary-log-debug-row">
+                    <span className="summary-log-debug-label">プロンプト</span>
+                    <pre className="summary-log-debug-prompt">{logDetail.prompt}</pre>
+                  </div>
+                </div>
               </>
             )}
           </div>
@@ -307,26 +528,58 @@ function SummaryResult({
 }) {
   return (
     <div className="interview-results">
-      <div className="interview-result-card">
-        <h3 className="result-question">主なトピック</h3>
-        <ul className="summary-result-list">
-          {summary.topics.map((topic, i) => (
-            <li key={i}>{topic}</li>
-          ))}
-        </ul>
-      </div>
+      {summary.overview && (
+        <div className="interview-result-card">
+          <h3 className="result-question">概要</h3>
+          <p className="summary-result-text">{summary.overview}</p>
+        </div>
+      )}
 
-      <div className="interview-result-card">
-        <h3 className="result-question">結論・合意事項</h3>
-        <p className="summary-result-text">{summary.conclusion}</p>
-      </div>
+      {summary.key_points?.length > 0 && (
+        <div className="interview-result-card">
+          <h3 className="result-question">キーポイント</h3>
+          <ul className="summary-result-list summary-key-points">
+            {summary.key_points.map((kp: SummaryKeyPoint, i: number) => (
+              <li key={i}>
+                <span className="summary-key-point-topic">{kp.topic}</span>
+                <span className="summary-key-point-summary">{kp.summary}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
-      {summary.actions.length > 0 && (
+      {summary.decisions?.length > 0 && (
+        <div className="interview-result-card">
+          <h3 className="result-question">決定事項</h3>
+          <ul className="summary-result-list">
+            {summary.decisions.map((decision: string, i: number) => (
+              <li key={i}>{decision}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {summary.actions?.length > 0 && (
         <div className="interview-result-card">
           <h3 className="result-question">次のアクション</h3>
+          <ul className="summary-result-list summary-actions">
+            {summary.actions.map((action: SummaryActionItem, i: number) => (
+              <li key={i}>
+                <span className="summary-action-speaker">{action.speaker}</span>
+                <span className="summary-action-task">{action.task}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {summary.open_questions?.length > 0 && (
+        <div className="interview-result-card">
+          <h3 className="result-question">未解決の質問</h3>
           <ul className="summary-result-list">
-            {summary.actions.map((action, i) => (
-              <li key={i}>{action}</li>
+            {summary.open_questions.map((q: string, i: number) => (
+              <li key={i}>{q}</li>
             ))}
           </ul>
         </div>

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -97,7 +97,7 @@ ${jsonShape}
 export function SummaryPage({ transcriptionId, onBack }: Props) {
   const [activeTab, setActiveTab] = useState<'new' | 'logs'>('new');
   const [summarizing, setSummarizing] = useState(false);
-  const [summary, setSummary] = useState<TranscriptionSummaryLog | null>(null);
+  const [completedId, setCompletedId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // 設定（モデル一覧・デフォルトプロンプト）
@@ -180,11 +180,12 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
     if (enabledCount === 0) return;
 
     setSummarizing(true);
+    setCompletedId(null);
     setError(null);
     try {
       const prompt = buildPrompt(fields);
       const result = await summarizeTranscription(transcriptionId, selectedModel, prompt);
-      setSummary(result);
+      setCompletedId(result.id);
       loadLogs();
     } catch (e) {
       setError(e instanceof Error ? e.message : '要約に失敗しました');
@@ -218,7 +219,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
       <div className="interview-tabs">
         <button
           className={`interview-tab ${activeTab === 'new' ? 'active' : ''}`}
-          onClick={() => setActiveTab('new')}
+          onClick={() => { setActiveTab('new'); setCompletedId(null); }}
         >
           新規要約
         </button>
@@ -226,7 +227,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
           className={`interview-tab ${activeTab === 'logs' ? 'active' : ''}`}
           onClick={() => setActiveTab('logs')}
         >
-          過去の要約ログ
+          要約結果
         </button>
       </div>
 
@@ -352,7 +353,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
               <button
                 className="interview-button primary"
                 onClick={handleSummarize}
-                disabled={summarizing || !selectedModel || enabledCount === 0}
+                disabled={summarizing || !!completedId || !selectedModel || enabledCount === 0}
               >
                 {summarizing ? '要約中...' : '要約する'}
               </button>
@@ -365,8 +366,19 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
               </div>
             )}
 
-            {summary && !summarizing && (
-              <SummaryResult summary={summary} formatDate={formatDate} />
+            {completedId && !summarizing && (
+              <div className="summary-completed">
+                <span className="summary-completed-message">✓ 要約が完了しました。</span>
+                <button
+                  className="summary-completed-link"
+                  onClick={() => {
+                    setActiveTab('logs');
+                    handleSelectLog(completedId);
+                  }}
+                >
+                  要約結果を見る →
+                </button>
+              </div>
             )}
           </section>
         </div>
@@ -376,7 +388,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
         <div className="interview-logs-layout">
           <div className="interview-logs-list">
             <div className="interview-logs-list-header">
-              <span>要約履歴</span>
+              <span>要約結果</span>
               <button
                 className="interview-logs-refresh"
                 onClick={loadLogs}
@@ -389,7 +401,7 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
             {logsLoading ? (
               <div className="interview-logs-empty">読み込み中...</div>
             ) : logs.length === 0 ? (
-              <div className="interview-logs-empty">過去の要約結果がありません</div>
+              <div className="interview-logs-empty">要約結果がありません</div>
             ) : (
               logs.map((log) => (
                 <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -137,13 +137,27 @@ export interface DeepSearchAnalysis {
 /** 会話分析ログサマリー（results を除いた一覧表示用） */
 export type InterviewAnalysisSummary = Omit<InterviewAnalysis, 'results'>;
 
+/** 要約のアクションアイテム */
+export interface SummaryActionItem {
+  speaker: string;
+  task: string;
+}
+
+/** 要約のキーポイント */
+export interface SummaryKeyPoint {
+  topic: string;
+  summary: string;
+}
+
 /** 要約ログ */
 export interface TranscriptionSummaryLog {
   id: string;
   transcriptionId: string;
-  topics: string[];
-  conclusion: string;
-  actions: string[];
+  overview?: string;
+  key_points?: SummaryKeyPoint[];
+  decisions?: string[];
+  actions?: SummaryActionItem[];
+  open_questions?: string[];
   createdAt: string;
   model: string;
   prompt: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -157,6 +157,7 @@ export interface AppSettings {
     transcriptionsDir: string;
     documentsDir: string;
     documentMetadataDir: string;
+    summaryLogsDir: string;
   };
   apiKeys: {
     elevenlabsApiKey: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -137,12 +137,6 @@ export interface DeepSearchAnalysis {
 /** 会話分析ログサマリー（results を除いた一覧表示用） */
 export type InterviewAnalysisSummary = Omit<InterviewAnalysis, 'results'>;
 
-/** 要約のアクションアイテム */
-export interface SummaryActionItem {
-  speaker: string;
-  task: string;
-}
-
 /** 要約のキーポイント */
 export interface SummaryKeyPoint {
   topic: string;
@@ -156,8 +150,6 @@ export interface TranscriptionSummaryLog {
   overview?: string;
   key_points?: SummaryKeyPoint[];
   decisions?: string[];
-  actions?: SummaryActionItem[];
-  open_questions?: string[];
   createdAt: string;
   model: string;
   prompt: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -145,6 +145,14 @@ export interface TranscriptionSummaryLog {
   conclusion: string;
   actions: string[];
   createdAt: string;
+  model: string;
+  prompt: string;
+}
+
+/** 要約設定（デフォルトプロンプト・モデル一覧） */
+export interface SummaryConfig {
+  defaultPrompt: string;
+  models: { id: string; label: string }[];
 }
 
 /** アプリ設定 */

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -137,6 +137,16 @@ export interface DeepSearchAnalysis {
 /** 会話分析ログサマリー（results を除いた一覧表示用） */
 export type InterviewAnalysisSummary = Omit<InterviewAnalysis, 'results'>;
 
+/** 要約ログ */
+export interface TranscriptionSummaryLog {
+  id: string;
+  transcriptionId: string;
+  topics: string[];
+  conclusion: string;
+  actions: string[];
+  createdAt: string;
+}
+
 /** アプリ設定 */
 export interface AppSettings {
   appVersion: string;


### PR DESCRIPTION
## Summary

### 要約画面の改善
- Anthropic公式推奨のプロンプト構造（XMLタグ・ロール宣言・会話→指示順）に刷新
- 要約フィールドを3項目に設計（overview / key_points [{topic, summary}] / decisions）
  - 「次のアクション」「未解決の質問」はこのアプリのユースケースに不要なため削除
- プロンプト編集フォームをHTMLフォーム方式に変更（テキストエリア廃止、key_pointsのサブフィールドを分割表示）
- Claudeへのインプットプレビューを常時表示に変更し「プロンプトを更新」ボタンを追加
- 過去ログ詳細にモデルIDとプロンプトを表示
- max_tokens を 2048 → 8192 に増やし長い音声のJSON切り捨てを修正
- 過去ログ一覧で key_points が undefined のログをクリックするとクラッシュするバグを修正

### 要約完了後のUX改善
- 要約完了後に「要約する」ボタンをdisabledにする
- 完了メッセージと「要約結果を見る →」リンクを表示
- リンククリックで「要約結果」タブへ遷移し、生成した要約を自動選択・表示
- 「新規要約」タブをクリックするとボタンが再び有効になりリセットされる
- タブラベル「過去の要約ログ」→「要約結果」に変更

### バックエンドのクラス設計改善
- ClaudeService を責務別に3クラスに分割
  - ClaudeClientService: Anthropicクライアント生成・axiosFetchの共通インフラ
  - AnalysisService: 会話分析・Web検索・ディープサーチ分析
  - SummaryService: 会話要約・DEFAULT_SUMMARY_PROMPT・SUMMARY_MODELS

### テスト追加
- `SummaryService` の単体テスト（正常系JSONパース・JSONなし・壊れたJSON・`{{fullText}}` 置換）
- `InterviewService` に要約機能テストを追加（ハッピーパス・存在しないログIDのNotFoundException・`getSummaryConfig`）

- Closes #141

## Test plan

### CI自動チェック（PRのChecksタブで確認）
- [x] `backend-test` がパスしていること
- [x] `frontend-test` がパスしていること

### 手動確認

**ビルド確認**（backend変更あり）
```bash
cd backend && npm run build
```
- [x] ビルドエラーがないこと

**動作確認**
```bash
# ai-speak-trace/ ルートディレクトリで実行
npm run dev
```

**要約機能**
- [x] 文字起こし履歴を選択し、右サイドバーの「要約」タブを開くと要約画面が表示されること
- [x] モデル選択セレクトボックスで3種類のモデルが選択できること
- [x] 各フィールドの指示を編集後「プロンプトを更新」を押すと、Claudeへのインプットプレビューに反映されること
- [x] 要約完了後に「要約する」ボタンがdisabledになり、「要約結果を見る →」リンクが表示されること
- [x] リンクをクリックすると「要約結果」タブに遷移し、生成した要約が自動選択・表示されること
- [x] 「新規要約」タブをクリックするとボタンが再び有効になること

**要約結果タブ**
- [x] 「要約結果」タブを開き、ログ一覧が表示されること
- [x] ログをクリックしても画面がクラッシュせず詳細が表示されること
- [x] 詳細画面の上部にモデルIDとプロンプトが表示されること

**設定画面**
- [x] 設定画面を開き、要約ログの保存先パスが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)