### PR TITLE
fix: 要約ページのプロンプトフィールドをカード型に統一する

### DIFF
--- a/frontend/src/components/SummaryPage.css
+++ b/frontend/src/components/SummaryPage.css
@@ -54,34 +54,15 @@
   margin-top: 0.75rem;
 }
 
-.summary-field-row {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-  background-color: #ffffff;
-}
-
-.summary-field-label {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: #374151;
-  white-space: nowrap;
-  min-width: 7rem;
-  flex-shrink: 0;
-}
-
-/* グループフィールド（key_points / actions） */
-.summary-field-group {
+/* 統一カードフィールド */
+.summary-field-card {
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background-color: #ffffff;
   overflow: hidden;
 }
 
-.summary-field-group-label {
+.summary-field-card-label {
   display: block;
   font-size: 0.85rem;
   font-weight: 500;
@@ -90,9 +71,10 @@
   border-bottom: 1px solid #f3f4f6;
 }
 
-.summary-field-group-rows {
-  display: flex;
-  flex-direction: column;
+.summary-field-card > .summary-field-instruction {
+  margin: 0.4rem 0.75rem;
+  width: calc(100% - 1.5rem);
+  box-sizing: border-box;
 }
 
 .summary-field-subrow {

--- a/frontend/src/components/SummaryPage.tsx
+++ b/frontend/src/components/SummaryPage.tsx
@@ -274,8 +274,8 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
             </p>
             <div className="summary-fields-form">
               {/* overview */}
-              <div className="summary-field-row">
-                <span className="summary-field-label">概要</span>
+              <div className="summary-field-card">
+                <span className="summary-field-card-label">概要</span>
                 <input
                   type="text"
                   className="summary-field-instruction"
@@ -286,30 +286,28 @@ export function SummaryPage({ transcriptionId, onBack }: Props) {
               </div>
 
               {/* key_points（グループ） */}
-              <div className="summary-field-group">
-                <span className="summary-field-group-label">キーポイント</span>
-                <div className="summary-field-group-rows">
-                  {(['key_points_topic', 'key_points_summary'] as const).map((key) => {
-                    const f = fields.find((f) => f.key === key)!;
-                    return (
-                      <div key={key} className="summary-field-subrow">
-                        <span className="summary-field-sublabel">{f.subLabel}</span>
-                        <input
-                          type="text"
-                          className="summary-field-instruction"
-                          placeholder={f.defaultInstruction}
-                          value={f.instruction}
-                          onChange={(e) => handleFieldInstruction(key, e.target.value)}
-                        />
-                      </div>
-                    );
-                  })}
-                </div>
+              <div className="summary-field-card">
+                <span className="summary-field-card-label">キーポイント</span>
+                {(['key_points_topic', 'key_points_summary'] as const).map((key) => {
+                  const f = fields.find((f) => f.key === key)!;
+                  return (
+                    <div key={key} className="summary-field-subrow">
+                      <span className="summary-field-sublabel">{f.subLabel}</span>
+                      <input
+                        type="text"
+                        className="summary-field-instruction"
+                        placeholder={f.defaultInstruction}
+                        value={f.instruction}
+                        onChange={(e) => handleFieldInstruction(key, e.target.value)}
+                      />
+                    </div>
+                  );
+                })}
               </div>
 
               {/* decisions */}
-              <div className="summary-field-row">
-                <span className="summary-field-label">決定事項</span>
+              <div className="summary-field-card">
+                <span className="summary-field-card-label">決定事項</span>
                 <input
                   type="text"
                   className="summary-field-instruction"


### PR DESCRIPTION
## Summary

- 概要・決定事項（`summary-field-row`）とキーポイント（`summary-field-group`）で異なっていたレイアウトを、すべて `summary-field-card` に統一した
- ラベルをカード上部に配置し、inputをその下に配置する構造に揃えた

## Test plan

- [x] CI自動チェック: `backend-test` が通過する
- [x] CI自動チェック: `frontend-test` が通過する
- [x] アプリを起動し（`npm run dev`）、文字起こし結果から要約ページを開く
- [x] 「概要」「キーポイント」「決定事項」の3フィールドが同じカード形式で表示されることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)